### PR TITLE
Criado logica para utilizar um prefix no banco Redis

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -64,6 +64,7 @@
     "redisHost": "localhost",
     "redisPort": 6379,
     "redisPassword": "",
-    "redisDb": 0
+    "redisDb": 0,
+    "redisPrefix": "docker"
   }
 }

--- a/src/util/functions.js
+++ b/src/util/functions.js
@@ -218,4 +218,16 @@ export function strToBool(s) {
   return /^(true|1)$/i.test(s);
 }
 
+export function getIPAddress() {
+  var interfaces = require('os').networkInterfaces();
+  for (var devName in interfaces) {
+    var iface = interfaces[devName];
+    for (var i = 0; i < iface.length; i++) {
+      var alias = iface[i];
+      if (alias.family === 'IPv4' && alias.address !== '127.0.0.1' && !alias.internal) return alias.address;
+    }
+  }
+  return '0.0.0.0';
+}
+
 export let unlinkAsync = promisify(fs.unlink);

--- a/src/util/tokenStore/redisTokenStory.js
+++ b/src/util/tokenStore/redisTokenStory.js
@@ -1,10 +1,16 @@
 import redisClient from '../db/redis/db';
+import config from '../../config.json';
+import { getIPAddress } from '../functions';
 
 var RedisTokenStore = function (client) {
+  let prefix = config.db.redisPrefix || '';
+  if (prefix === 'docker') {
+    prefix = getIPAddress();
+  }
   this.tokenStore = {
     getToken: (sessionName) =>
       new Promise((resolve, reject) => {
-        redisClient.get(sessionName, (err, reply) => {
+        redisClient.get(prefix + sessionName, (err, reply) => {
           if (err) {
             return reject(err);
           }
@@ -15,22 +21,27 @@ var RedisTokenStore = function (client) {
       new Promise((resolve) => {
         tokenData.sessionName = sessionName;
         tokenData.config = client.config;
-        redisClient.set(sessionName, JSON.stringify(tokenData), (err) => {
+        redisClient.set(prefix + sessionName, JSON.stringify(tokenData), (err) => {
           return resolve(err ? false : true);
         });
       }),
     removeToken: (sessionName) =>
       new Promise((resolve) => {
-        redisClient.del(sessionName, (err) => {
+        redisClient.del(prefix + sessionName, (err) => {
           return resolve(err ? false : true);
         });
       }),
     listTokens: () =>
       new Promise((resolve) => {
-        redisClient.keys('*', (err, keys) => {
+        redisClient.keys(prefix + '*', (err, keys) => {
           if (err) {
             return resolve([]);
           }
+          keys.forEach((item, indice) => {
+            if (prefix !== '' && item.includes(prefix)) {
+              keys[indice] = item.substring(item.indexOf(prefix) + prefix.length);
+            }
+          });
           return resolve(keys);
         });
       }),


### PR DESCRIPTION
Criado a logica para utilizar um prefix quando for utilizar o banco Redis.
Assim não pegando chaves de outro sistema que não lhe pertence.
Adicionado também quando colocar a palavra 'docker' o prefix e gerado pelo ip do server, assim mesmo se 
levantar vários container com a mesma imagem cada prefix será diferente permitindo um load balance.