### PR TITLE
feat(release): Implementado método para mandar lista de botões

### DIFF
--- a/src/controller/messageController.js
+++ b/src/controller/messageController.js
@@ -180,6 +180,39 @@ export async function sendButtons(req, res) {
   }
 }
 
+export async function sendButtonsList(req, res) {
+  const { phone, message = '', title, buttons, buttonText = 'SELECIONE UMA OPÇÃO' } = req.body;
+
+  try {
+    let results = [];
+
+    for (const contact of phone) {
+      results.push(
+        await req.client.sendMessageOptions(contact, null, {
+          type: 'list',
+          list: {
+            listType: 1,
+            title: title,
+            description: message,
+            buttonText: buttonText,
+            sections: [
+              {
+                rows: buttons,
+              },
+            ],
+          },
+        })
+      );
+    }
+
+    if (results.length === 0) return returnError(req, res, 'Error sending list buttons');
+
+    returnSucess(res, phone, results);
+  } catch (error) {
+    returnError(req, res, error);
+  }
+}
+
 export async function sendStatusText(req, res) {
   const { message } = req.body;
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -26,6 +26,7 @@ import multer from 'multer';
 import uploadConfig from '../config/upload';
 import swaggerUi from 'swagger-ui-express';
 import swaggerDocument from '../swagger.json';
+import { sendButtonsList } from '../controller/messageController';
 
 const upload = multer(uploadConfig);
 const routes = new Router();
@@ -74,6 +75,7 @@ routes.post('/api/:session/send-link-preview', verifyToken, statusConnection, Me
 routes.post('/api/:session/send-location', verifyToken, statusConnection, MessageController.sendLocation);
 routes.post('/api/:session/send-mentioned', verifyToken, statusConnection, MessageController.sendMentioned);
 routes.post('/api/:session/send-buttons', verifyToken, statusConnection, MessageController.sendButtons);
+routes.post('/api/:session/send-buttons-list', verifyToken, statusConnection, MessageController.sendButtonsList);
 
 // Group
 routes.get('/api/:session/all-broadcast-list', verifyToken, statusConnection, GroupController.getAllBroadcastList);


### PR DESCRIPTION
Adicionado a possibilidade de mandar uma lista de botões, pelo método sendButtonsList, buttons tem que ser array de objetos {"title": "Opção 1","rowId": "01"}