### PR TITLE
fix(dev): Corrigido erro ao carregar token pelo redis

### DIFF
--- a/src/util/tokenStore/redisTokenStory.js
+++ b/src/util/tokenStore/redisTokenStory.js
@@ -15,8 +15,10 @@ var RedisTokenStore = function (client) {
             return reject(err);
           }
           const object = JSON.parse(reply);
-          if (object.config && Object.keys(client.config).length === 0) client.config = object.config;
-          if (object.webhook && Object.keys(client.config).length === 0) client.config.webhook = object.webhook;
+          if (object) {
+            if (object.config && Object.keys(client.config).length === 0) client.config = object.config;
+            if (object.webhook && Object.keys(client.config).length === 0) client.config.webhook = object.webhook;
+          }
           resolve(object);
         });
       }),


### PR DESCRIPTION
Quando não e feito o Json.Parse corretamente e retornado um null no lugar do objeto o que esta causando alguns erros durante a leitura dos tokens.