### PR TITLE
Mensagens privadas do ChatWoot

### DIFF
--- a/src/controller/deviceController.js
+++ b/src/controller/deviceController.js
@@ -663,7 +663,7 @@ export async function chatWoot(req, res) {
     if (await client.isConnected()) {
       const event = req.body.event;
 
-      if (event == 'conversation_status_changed' || event == 'conversation_resolved') {
+      if (event == 'conversation_status_changed' || event == 'conversation_resolved' || req.body.private) {
         return res.status(200).json({ status: 'success', message: 'Success on receive chatwoot' });
       }
 


### PR DESCRIPTION
As mensagens privadas não devem ser tratadas no WPPConnect, elas são internas no ChatWoot e não devem ser encaminhadas.