### PR TITLE
Não gerar contato duplicado

### DIFF
--- a/src/util/chatWootClient.js
+++ b/src/util/chatWootClient.js
@@ -37,15 +37,17 @@ export default class chatWootClient {
 
     //assina o evento do qrcode
     eventEmitter.on(`qrcode-${session}`, (qrCode, urlCode, client) => {
-      this.sendMessage(client, {
-        sender: this.sender,
-        chatId: '',
-        type: 'image',
-        timestamp: 'qrcode',
-        mimetype: 'image/png',
-        caption: 'leia o qrCode',
-        qrCode: qrCode.replace('data:image/png;base64,', ''),
-      });
+      setTimeout(async () => {
+        this.sendMessage(client, {
+          sender: this.sender,
+          chatId: '',
+          type: 'image',
+          timestamp: 'qrcode',
+          mimetype: 'image/png',
+          caption: 'leia o qrCode',
+          qrCode: qrCode.replace('data:image/png;base64,', ''),
+        });
+      }, 1000);
     });
 
     //assiona o evento do status


### PR DESCRIPTION
Quando a start session ocorre na primeira vez os eventos qrcode e status são gerados praticamente em simultâneo, com isso são gerados dois contatos dentro do chatwoot, adicionando atraso em um deles é possivel mitigar este comportamento, achei melhor adicionar o delay no qrcode pois ele é um evento que ocorre menos vezes do que o status.