### PR TITLE
Evita criar conversas adicionais erroneamente

### DIFF
--- a/src/util/chatWootClient.js
+++ b/src/util/chatWootClient.js
@@ -173,7 +173,7 @@ export default class chatWootClient {
       const { data } = await this.api.get(
         `api/v1/accounts/${this.account_id}/conversations?inbox_id=${this.inbox_id}&status=all`
       );
-      return data.data.payload.find((e) => e.meta.sender.id == contact.id && e.status != "resolved");
+      return data.data.payload.find((e) => e.meta.sender.id == contact.id && e.status != 'resolved');
     } catch (e) {
       console.log(e);
       return null;

--- a/src/util/chatWootClient.js
+++ b/src/util/chatWootClient.js
@@ -171,9 +171,9 @@ export default class chatWootClient {
   async findConversation(contact) {
     try {
       const { data } = await this.api.get(
-        `api/v1/accounts/${this.account_id}/conversations?inbox_id=${this.inbox_id}&status=open`
+        `api/v1/accounts/${this.account_id}/conversations?inbox_id=${this.inbox_id}&status=all`
       );
-      return data.data.payload.find((e) => e.meta.sender.id == contact.id);
+      return data.data.payload.find((e) => e.meta.sender.id == contact.id && e.status != "resolved");
     } catch (e) {
       console.log(e);
       return null;


### PR DESCRIPTION
O filtro de status estava sendo feito apenas para conversas com status 'open', porém existem os status 'pending' e 'snoozed' que também devem ser consideradas como conversas ainda abertas... principalmente quando um robô é utilizado para o atendimento, nesse caso todas as conversas iniciam no com status 'pending', antes de fazer esse ajuste no código não estava conseguindo dar seguimento no fluxo do meu dialogflow porque a cada nova resposta ele gerava uma nova conversa...