### PR TITLE
Alterar source_id do contato

### DIFF
--- a/src/util/chatWootClient.js
+++ b/src/util/chatWootClient.js
@@ -68,7 +68,7 @@ export default class chatWootClient {
   async sendMessage(client, message) {
     if (message.isGroupMsg || message.chatId.indexOf('@broadcast') > 0) return;
     let contact = await this.createContact(message);
-    let conversation = await this.createConversation(contact, message.id);
+    let conversation = await this.createConversation(contact, message.chatId.split('@')[0]);
 
     try {
       if (


### PR DESCRIPTION
O source_id do contato não pode ser a message.id da primeira interação porque ela contem '@', e isso impede o uso do source_id em alguns endpoints do chatwoot impossibilitando por exemplo o UPDATE de mensagens. Alterei para que o source_id cadastrado seja o próprio numero de telefone pois ele será único entre os contatos nessa inbox do chatwoot.