### PR TITLE
Adds simple Dockerfile and docker-compose example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.hust
+*.tgz
+dist
+log
+node_modules
+npm-debug.log
+tokens

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:14-alpine as base
+WORKDIR /usr/src/wpp-server
+ENV NODE_ENV=production PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+COPY package.json yarn.lock ./
+RUN yarn install --production --pure-lockfile && \
+    yarn cache clean
+
+FROM base as build
+WORKDIR /usr/src/wpp-server
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+COPY package.json yarn.lock ./
+RUN yarn install --production=false --pure-lockfile && \
+    yarn cache clean
+COPY . .
+RUN yarn build
+
+
+FROM base
+WORKDIR /usr/src/wpp-server/
+RUN apk add --no-cache chromium
+RUN yarn cache clean
+COPY . .
+COPY --from=build /usr/src/wpp-server/ /usr/src/wpp-server/
+EXPOSE 21465
+ENTRYPOINT ["node", "dist/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.4"
+
+volumes:
+  wppconnect_tokens: {}
+
+services:
+  wppconnect:
+    build:
+      context: .
+    volumes:
+      - ./config.json:/usr/src/wpp-server/config.json
+      - wppconnect_tokens:/usr/src/wpp-server/tokens
+    ports:
+      - "21465:21465"


### PR DESCRIPTION
as is hard to [server-cli](https://github.com/wppconnect-team/server-cli) keep up with wppconnect-server new features, this will allow to use wppconnect-server directly mounting the configuration file and volume for token, as suggested on docker-compose :)