### PR TITLE
fix(message): fix sendFileFromBase64 with options

### DIFF
--- a/src/controller/messageController.js
+++ b/src/controller/messageController.js
@@ -101,7 +101,7 @@ export async function sendFile64(req, res) {
   try {
     let results = [];
     for (const contato of phone) {
-      results.push(await req.client.sendFile(contato, base64, options.length > 0 ? options : filename));
+      results.push(await req.client.sendFile(contato, base64, Object.keys(options).length > 0 ? options : filename));
     }
 
     if (results.length === 0) return res.status(400).json('Error sending message');


### PR DESCRIPTION
This commit https://github.com/wppconnect-team/wppconnect-server/commit/3016f2f7ad65d18e762f51b98bdcb53bfd5ad8b5 from @icleitoncosta sadly breaked up sending options with image/file

so here is a quick fix.

because `options` is obj. not array to do `.length` with it.
so `options.length` is always `undefined` and now returns number / length