### PR TITLE
fix: fixing set-cart-enable route

### DIFF
--- a/src/controller/catalogController.js
+++ b/src/controller/catalogController.js
@@ -200,7 +200,7 @@ export async function updateCartEnabled(req, res) {
     });
 
   try {
-    const result = await req.client.setProductVisibility(enabled);
+    const result = await req.client.updateCartEnabled(enabled);
     res.status(201).json({ status: 'success', response: result });
   } catch (error) {
     res.status(500).json({ status: 'Error', message: 'Error on set enabled cart.', error: error });


### PR DESCRIPTION
```
export async function setProductVisibility(req, res) {
  const { id, value } = req.body;
  if (!id || !value)
    return res.status(401).send({
      message: 'product id or value (false, true) was not informed',
    });

  try {
    const result = await req.client.setProductVisibility(id, value);    <<<<<<<===============
    res.status(201).json({ status: 'success', response: result });
  } catch (error) {
    res.status(500).json({ status: 'Error', message: 'Error on set product visibility.', error: error });
  }
}

export async function updateCartEnabled(req, res) {
  const { enabled } = req.body;
  if (!enabled)
    return res.status(401).send({
      message: 'enabled (false, true) was not informed',
    });

  try {
    const result = await req.client.setProductVisibility(enabled);    <<<<<<<===============
    res.status(201).json({ status: 'success', response: result });
  } catch (error) {
    res.status(500).json({ status: 'Error', message: 'Error on set enabled cart.', error: error });
  }
}
```

Duas rotas com objetivos diferentes, mas  chamando o mesmo metodo do client. Fiz uma modificacao para usar o metodo correto, e agora a rota set-cart-enable funciona corretamente. vide #1070 
