### PR TITLE
Dynamic Device Name

### DIFF
--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -68,8 +68,8 @@ export default class CreateSessionUtil {
           req.serverOptions.createOptions,
           {
             session: session,
-            deviceName: client.config?.options?.deviceName || req.serverOptions.deviceName,
-            poweredBy: client.config?.options?.poweredBy || req.serverOptions.poweredBy || 'WPPConnect-Server',
+            deviceName: client.config?.deviceName || req.serverOptions.deviceName,
+            poweredBy: client.config?.poweredBy || req.serverOptions.poweredBy || 'WPPConnect-Server',
             catchQR: (
               base64Qr: any,
               asciiQR: any,

--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -68,11 +68,11 @@ export default class CreateSessionUtil {
           req.serverOptions.createOptions,
           {
             session: session,
-            deviceName: 
+            deviceName:
               client.config?.deviceName || req.serverOptions.deviceName,
             poweredBy: 
-              client.config?.poweredBy || 
-              req.serverOptions.poweredBy || 
+              client.config?.poweredBy ||
+              req.serverOptions.poweredBy ||
               'WPPConnect-Server',
             catchQR: (
               base64Qr: any,

--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -68,8 +68,12 @@ export default class CreateSessionUtil {
           req.serverOptions.createOptions,
           {
             session: session,
-            deviceName: client.config?.deviceName || req.serverOptions.deviceName,
-            poweredBy: client.config?.poweredBy || req.serverOptions.poweredBy || 'WPPConnect-Server',
+            deviceName: 
+              client.config?.deviceName || req.serverOptions.deviceName,
+            poweredBy: 
+              client.config?.poweredBy || 
+              req.serverOptions.poweredBy || 
+              'WPPConnect-Server',
             catchQR: (
               base64Qr: any,
               asciiQR: any,

--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -68,8 +68,8 @@ export default class CreateSessionUtil {
           req.serverOptions.createOptions,
           {
             session: session,
-            deviceName: req.serverOptions.deviceName,
-            poweredBy: req.serverOptions.poweredBy || 'WPPConnect-Server',
+            deviceName: client.config?.options?.deviceName || req.serverOptions.deviceName,
+            poweredBy: client.config?.options?.poweredBy || req.serverOptions.poweredBy || 'WPPConnect-Server',
             catchQR: (
               base64Qr: any,
               asciiQR: any,


### PR DESCRIPTION
Issue: https://github.com/wppconnect-team/wppconnect-server/issues/1307

Basta passar no corpo da requisição /start-session, os valores de `deviceName` e `poweredBy` em `options`.
```
CURL POST /start-session
"options": {
    "deviceName": "My Device",
    "poweredBy": "My Powered"
}
```