### PR TITLE
add new flag initialize session

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ This server use config.ts file to define some options, default values are:
       '--ignore-certificate-errors',
       '--ignore-ssl-errors',
       '--ignore-certificate-errors-spki-list',
+      '--disable-features=LeakyPeeker' // Disable the browser's sleep mode when idle, preventing the browser from going into sleep mode, this is useful for WhatsApp not to be in economy mode in the background, avoiding possible crashes
     ],
   },
   mapper: {


### PR DESCRIPTION
Disable the browser's sleep mode when idle, preventing the browser from going into sleep mode, this is useful for WhatsApp not to be in economy mode in the background, avoiding possible crashes