### PR TITLE
feat: Added onSelfMessage event for Webhook

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ export default {
     onPollResponse: true,
     onRevokedMessage: true,
     onLabelUpdated: true,
+    onSelfMessage: false,
   },
   chatwoot: {
     sendQrCode: true,

--- a/src/types/ServerOptions.ts
+++ b/src/types/ServerOptions.ts
@@ -20,6 +20,7 @@ export interface ServerOptions {
     onReactionMessage: boolean;
     onPollResponse: boolean;
     onRevokedMessage: boolean;
+    onSelfMessage: boolean;
   };
   archive: {
     enable: boolean;

--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -230,7 +230,7 @@ export default class CreateSessionUtil {
 
       req.io.emit('received-message', { response: message });
       if (req.serverOptions.webhook.onSelfMessage && message.fromMe)
-        callWebHook(client, req, 'onSelfMessage', message);
+        callWebHook(client, req, 'onselfmessage', message);
     });
 
     await client.onIncomingCall(async (call) => {

--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -229,6 +229,8 @@ export default class CreateSessionUtil {
       }
 
       req.io.emit('received-message', { response: message });
+      if (req.serverOptions.webhook.onSelfMessage && message.fromMe)
+        callWebHook(client, req, 'onSelfMessage', message);
     });
 
     await client.onIncomingCall(async (call) => {


### PR DESCRIPTION
Evento possibilitará webhook receber mensagens enviadas pelo dispositivo conectado (casos onde há envio da mensagem sem utilizar as rotas de send message), aprimorando a ausência da perda de mensagens pelo sistema do webhook.

Padrão está como false para não impactar em atualizações de projetos já existentes.