### PR TITLE
Se existe bucket padrão setado não precisa verificar se existe

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ This server use config.ts file to define some options, default values are:
     region: 'sa-east-1',
     access_key_id: '',
     secret_key: '',
+    // If you already have a bucket created that will be used. Will bestored: you-default-bucket/{session}/{filename}
+    defaultBucketName: ''
   },
 }
 ```

--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -161,7 +161,10 @@ async function autoDownload(client: any, req: any, message: any) {
           config.aws_s3.defaultBucketName ? client.session + '/' : ''
         }${hashName}.${mime.extension(message.mimetype)}`;
 
-        if (!(await bucketAlreadyExists(bucketName))) {
+        if (
+          !config.aws_s3.defaultBucketName &&
+          !(await bucketAlreadyExists(bucketName))
+        ) {
           await s3Client.send(
             new CreateBucketCommand({
               Bucket: bucketName,


### PR DESCRIPTION
### Introdução
Atualmente mesmo com o defaultBucketName setado, ele verifica se existe aquele bucket, o que não faz muito sentido, pois pela lógica se setei o bucket padrão, ele já deve (ou deveria) existir no S3.

### Melhorias
A melhoria é muito simples, se já tiver o bucket padrão setado, não verifica se existe e posteriormente criando. Com essa mudança, tem duas principais melhorias:

1. Evitando requests desnecessários pra AWS S3 (quando verifica se existe o bucket, criando o bucket)
2. Isolando o user IAM da AWS pra ter acesso somente ao bucket padrão

### IAM da AWS
Com essa melhoria, você só precisa criar um usuário com a seguinte política:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Stmt1688754007727",
            "Action": [
                "s3:ListBucket",
                "s3:GetObject",
                "s3:PutObject",
                "s3:PutObjectAcl",
                "s3:PutObjectTagging"
            ],
            "Effect": "Allow",
            "Resource": "arn:aws:s3:::seu-bucket-nome/*"
        }
    ]
}
```

Atualmente, você precisa setar um usuário da IAM com acesso à todos as funções do S3, o que não pode ser muito seguro.