### PR TITLE
fix issue #1738

### DIFF
--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -241,7 +241,8 @@ export default class CreateSessionUtil {
 
       if (
         req.serverOptions?.websocket?.autoDownload ||
-        req.serverOptions?.webhook?.autoDownload
+        req.serverOptions?.webhook?.autoDownload &&
+        message.fromMe==false
       ) {
         await autoDownload(client, req, message);
       }

--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -241,8 +241,7 @@ export default class CreateSessionUtil {
 
       if (
         req.serverOptions?.websocket?.autoDownload ||
-        req.serverOptions?.webhook?.autoDownload &&
-        message.fromMe==false
+        (req.serverOptions?.webhook?.autoDownload && message.fromMe == false)
       ) {
         await autoDownload(client, req, message);
       }


### PR DESCRIPTION
This fix checks if message was received (encrypted) and not sent (causing error, because there is no media and it's not possible decrypt)