### PR TITLE
Update operationId at /api/{session}/status-session in swagger.json

### DIFF
--- a/src/swagger.json
+++ b/src/swagger.json
@@ -1209,7 +1209,7 @@
       "get": {
         "tags": ["Auth"],
         "description": "",
-        "operationId": "closeSession",
+        "operationId": "statusSession",
         "parameters": [
           {
             "name": "session",


### PR DESCRIPTION
operationId was type incorrectly. Status session operationId was closeSession