### PR TITLE
Fechar sessão em caso de erro no Puppeter (Error no open bowser) (Initializing)

### DIFF
--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -144,6 +144,10 @@ export default class CreateSessionUtil {
       }
     } catch (e) {
       req.logger.error(e);
+      if (e instanceof Error && e.name == "TimeoutError") {
+        let client = this.getClient(session) as any;
+        client.status = 'CLOSED'
+      }
     }
   }
 


### PR DESCRIPTION
Caso ocorra um timeout no Puppeteer, será gerada a seguinte exceção:

```python
error:    [teste:browser] Error no open browser
error:    [teste:browser] Timed out after 30000 ms while waiting for the WS endpoint URL to appear in stdout!
error: 2024-07-30T16:54:11.637Z Timed out after 30000 ms while waiting for the WS endpoint URL to appear in stdout! - TimeoutError: Timed out after 30000 ms while waiting for the WS endpoint URL to appear in stdout!
    at ChromeLauncher.launch (/usr/src/wpp-server/node_modules/puppeteer-core/lib/cjs/puppeteer/node/ProductLauncher.js:150:23)
    at async PuppeteerExtra.launch (/usr/src/wpp-server/node_modules/puppeteer-extra/dist/index.cjs.js:128:25)
```

No meu caso, o problema ocorria porque algumas vezes a instância demorava um pouco mais para iniciar na primeira execução, mas em chamadas subsequentes, tudo funcionava corretamente. No entanto, como não havia tratamento adequado para exceções, a sessão do WppConnect permanecia indefinidamente no estado "Initializing", em vez de reverter para "Closed" em caso de erro.

Isso resultava em uma sessão que ficava em um estado de "limbo", impossibilitada de ser deletada ou reiniciada. Este PR propõe corrigir essa situação, revertendo o status para "Closed" em caso de erro no Puppeteer.

Para facilitar os testes, é possível adicionar o seguinte código na linha 56 do `createSessionUtil.ts` :

```typescript
      const { timeout = 30000 } = req.body;
      if (req.serverOptions.customUserDataDir) {
        req.serverOptions.createOptions.puppeteerOptions = {
          userDataDir: req.serverOptions.customUserDataDir + session,
          timeout: timeout 
      };
```
Fazendo isso, você poderá manipular o timeout do Puppeteer passando o parâmetro timeout no body do /start-session. Isso permite simular um cenário de cold start do navegador, definindo um timeout baixo na primeira requisição para forçar o erro e depois novamente com o timeout normal. Com as alterações deste PR, será possível reiniciar a mesma sessão sem precisar criar uma nova.




