### PR TITLE
Not reading QRCode when starting a session

### DIFF
--- a/src/controller/sessionController.ts
+++ b/src/controller/sessionController.ts
@@ -511,9 +511,21 @@ export async function getQrCode(req: Request, res: Response) {
    */
   try {
     if (req?.client?.urlcode) {
+
+      // We add options to generate the QR code in higher resolution
+      // The /qrcode-session request will now return a readable qrcode.
+      const qrOptions = {
+        errorCorrectionLevel: 'M' as const,
+        type: 'image/png' as const,
+        scale: 5,
+        width: 500,
+      };
+
       const qr = req.client.urlcode
         ? await QRCode.toDataURL(req.client.urlcode)
+        ? await QRCode.toDataURL(req.client.urlcode, qrOptions)
         : null;
+      
       const img = Buffer.from(
         (qr as any).replace(/^data:image\/(png|jpeg|jpg);base64,/, ''),
         'base64'

--- a/src/controller/sessionController.ts
+++ b/src/controller/sessionController.ts
@@ -511,7 +511,6 @@ export async function getQrCode(req: Request, res: Response) {
    */
   try {
     if (req?.client?.urlcode) {
-
       // We add options to generate the QR code in higher resolution
       // The /qrcode-session request will now return a readable qrcode.
       const qrOptions = {

--- a/src/controller/sessionController.ts
+++ b/src/controller/sessionController.ts
@@ -522,7 +522,6 @@ export async function getQrCode(req: Request, res: Response) {
       };
 
       const qr = req.client.urlcode
-        ? await QRCode.toDataURL(req.client.urlcode)
         ? await QRCode.toDataURL(req.client.urlcode, qrOptions)
         : null;
       

--- a/src/controller/sessionController.ts
+++ b/src/controller/sessionController.ts
@@ -520,16 +520,13 @@ export async function getQrCode(req: Request, res: Response) {
         scale: 5,
         width: 500,
       };
-
       const qr = req.client.urlcode
         ? await QRCode.toDataURL(req.client.urlcode, qrOptions)
         : null;
-      
       const img = Buffer.from(
         (qr as any).replace(/^data:image\/(png|jpeg|jpg);base64,/, ''),
         'base64'
       );
-
       res.writeHead(200, {
         'Content-Type': 'image/png',
         'Content-Length': img.length,


### PR DESCRIPTION
The base64 qrcode returned after session creation was not detected by whatsapp app. This problem has been eliminated by adding qrOptions.