### PR TITLE
build: Small change in the case sensitive for the reserved words to A…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.18 as base
+FROM node:lts-alpine3.18 AS base
 WORKDIR /usr/src/wpp-server
 ENV NODE_ENV=production PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 COPY package.json ./
@@ -15,7 +15,7 @@ RUN yarn install --production --pure-lockfile && \
     yarn add sharp --ignore-engines && \
     yarn cache clean
 
-FROM base as build
+FROM base AS build
 WORKDIR /usr/src/wpp-server
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 COPY package.json  ./


### PR DESCRIPTION
I tried to explain the problem in the issue #2113 
which is showing warnings during the docker build.

The solution is simple by changing the "as" to "AS"  and avoiding those warnings 