### PR TITLE
feat: set online presence (Fixes notification does not receive on iOS when wppconnect is connected)

### DIFF
--- a/src/controller/sessionController.ts
+++ b/src/controller/sessionController.ts
@@ -672,6 +672,52 @@ export async function subscribePresence(req: Request, res: Response) {
   }
 }
 
+export async function setOnlinePresence(req: Request, res: Response) {
+  /**
+   * #swagger.tags = ["Misc"]
+     #swagger.operationId = 'setOnlinePresence'
+     #swagger.autoBody=false
+     #swagger.security = [{
+            "bearerAuth": []
+     }]
+     #swagger.parameters["session"] = {
+      schema: 'NERDWHATS_AMERICA'
+     }
+     #swagger.requestBody = {
+      required: true,
+      "@content": {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              isOnline: { type: "boolean" },
+            }
+          },
+          example: {
+   isOnline: false,
+          }
+        }
+      }
+     }
+   */
+  try {
+    const { isOnline = true } = req.body;
+
+    await req.client.setOnlinePresence(isOnline);
+
+    res.status(200).json({
+      status: 'success',
+      response: { message: 'Set Online Presence Successfully' },
+    });
+  } catch (error) {
+    res.status(500).json({
+      status: 'error',
+      message: 'Error on set online presence',
+      error: error,
+    });
+  }
+}
+
 export async function editBusinessProfile(req: Request, res: Response) {
   /**
    * #swagger.tags = ["Profile"]

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -96,6 +96,11 @@ routes.post(
   SessionController.subscribePresence
 );
 routes.post(
+  '/api/:session/set-online-presence',
+  verifyToken,
+  SessionController.setOnlinePresence
+);
+routes.post(
   '/api/:session/download-media',
   verifyToken,
   statusConnection,


### PR DESCRIPTION
feat: set online presence (Fixes iOS notification issue when wppconnect is connected)

Summary

This PR sets the user’s online presence using the setOnlinePresence endpoint. This resolves an issue where push notifications were not being received on iOS devices when WPPConnect was connected.

Context

When WPPConnect maintains an active session, iOS devices may not receive notifications due to the device being considered “online”. By explicitly setting the online presence, we ensure proper notification delivery behavior on iOS.

Changes
	•	Call to setOnlinePresence added to enforce the correct presence state
	•	Ensures that notification delivery works correctly when WPPConnect is active

Fixes
	•	Push notifications not received on iOS while WPPConnect is connected
	•	Fixes: https://github.com/wppconnect-team/wppconnect-server/issues/1010
	•	Related: https://github.com/wppconnect-team/wppconnect/issues/1758
	•	Related: https://github.com/wppconnect-team/wppconnect/issues/1623
	•	Related: https://github.com/wppconnect-team/wppconnect/issues/1484
	•	Related: https://github.com/wppconnect-team/wppconnect/issues/2434

Notes

Tested on devices with active WPPConnect sessions to confirm notification delivery.
