### PR TITLE
Bugfix: Repeating messages when sending private messages on chatwoot

### DIFF
--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -2252,14 +2252,16 @@ export async function chatWoot(req: Request, res: Response): Promise<any> {
   try {
     if (await client.isConnected()) {
       const event = req.body.event;
-      const is_private = req.body.private || req.body.is_private
+      const is_private = req.body.private || req.body.is_private;
 
       if (
         event == 'conversation_status_changed' ||
         event == 'conversation_resolved' ||
         is_private
       ) {
-        return res.status(200).json({ status: 'success', message: 'Success on receive chatwoot' });
+        return res
+          .status(200)
+          .json({ status: 'success', message: 'Success on receive chatwoot' });
       }
 
       const {
@@ -2269,7 +2271,9 @@ export async function chatWoot(req: Request, res: Response): Promise<any> {
       } = req.body;
 
       if (event != 'message_created' && message_type != 'outgoing')
-        return res.status(200).json({ status: 'success', message: 'Success on receive chatwoot' });
+        return res
+          .status(200)
+          .json({ status: 'success', message: 'Success on receive chatwoot' });
       for (const contato of contactToArray(phone, false)) {
         if (message_type == 'outgoing') {
           if (message.attachments) {
@@ -2288,7 +2292,6 @@ export async function chatWoot(req: Request, res: Response): Promise<any> {
                 message.content
               );
             }
-            
             await client.sendFile(
               `${contato}`,
               base_url,

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -2252,15 +2252,14 @@ export async function chatWoot(req: Request, res: Response): Promise<any> {
   try {
     if (await client.isConnected()) {
       const event = req.body.event;
+      const is_private = req.body.private || req.body.is_private
 
       if (
         event == 'conversation_status_changed' ||
         event == 'conversation_resolved' ||
-        req.body.private
+        is_private
       ) {
-        res
-          .status(200)
-          .json({ status: 'success', message: 'Success on receive chatwoot' });
+        return res.status(200).json({ status: 'success', message: 'Success on receive chatwoot' });
       }
 
       const {
@@ -2270,7 +2269,7 @@ export async function chatWoot(req: Request, res: Response): Promise<any> {
       } = req.body;
 
       if (event != 'message_created' && message_type != 'outgoing')
-        res.status(200);
+        return res.status(200).json({ status: 'success', message: 'Success on receive chatwoot' });
       for (const contato of contactToArray(phone, false)) {
         if (message_type == 'outgoing') {
           if (message.attachments) {


### PR DESCRIPTION
When sending a private message from chatwoot, nothing should happen in the whatsapp chat, since it's just a internal message

When sending private messages, the last, non-private, message is sent to whatsapp insted, repeating the last message sent.

Return early when the message is private.