### PR TITLE
Fix: repeating last audio message to user in chatwoot, incorrect call to async function and http request keep open without return HTTP status to chatwoot webhook when sending audio

### DIFF
--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -2285,19 +2285,20 @@ export async function chatWoot(req: Request, res: Response): Promise<any> {
 
             // Check if attachments is Push-to-talk and send this
             if (message.attachments[0].file_type === 'audio') {
-              return client.sendPtt(
+              await client.sendPtt(
                 `${contato}`,
                 base_url,
                 'Voice Audio',
                 message.content
               );
+            } else {
+              await client.sendFile(
+                `${contato}`,
+                base_url,
+                'file',
+                message.content
+              );
             }
-            await client.sendFile(
-              `${contato}`,
-              base_url,
-              'file',
-              message.content
-            );
           } else {
             await client.sendText(contato, message.content);
           }


### PR DESCRIPTION
Fix repeated audio messages sent by Chatwoot due to missing HTTP 200 response

Previously, the last audio sent by Chatwoot to the user was being repeated multiple times because the sendPtt function did not return an HTTP 200 status code. As a result, the TCP connection for the request remained open until Chatwoot's 5000ms timeout, after which Chatwoot would mark the request as failed (red error in the UI) and attempt to resend it.

Now, the it waits for the async sendPtt function to finish and then correctly returns a success response (HTTP 200), properly closing the connection and preventing repeated messages. This also ensures sendPtt is used asynchronously as intended.