### PR TITLE
Fix: webhook's s3's fileUrl link when when using custom S3 endpoint

### DIFF
--- a/src/util/functions.ts
+++ b/src/util/functions.ts
@@ -228,7 +228,13 @@ export async function autoDownload(client: any, req: any, message: any) {
         );
 
         if (config?.aws_s3?.endpoint) {
-          message.fileUrl = `${config.aws_s3.endpoint}/${bucketName}/${fileName}`;
+          const url = new URL(config.aws_s3.endpoint);
+          const forcePathStyle = config?.aws_s3?.forcePathStyle ?? true;
+          if (forcePathStyle) {
+            message.fileUrl = `${url.protocol}//${url.host}/${bucketName}/${fileName}`;
+          } else {
+            message.fileUrl = `${url.protocol}//${bucketName}.${url.host}/${fileName}`;
+          }
         } else {
           message.fileUrl = `https://${bucketName}.s3.amazonaws.com/${fileName}`;
         }


### PR DESCRIPTION
Webhook always sent a hardcoded aws S3, even when a custom endpoint was set `aws_s3.endpoint` (e.g., for MinIO, DigitalOcean Spaces). The fileUrl now correctly uses the custom endpoint (if it exists) in forced path-style format (more compatible with s3 endpoints) instead of the hardcoded AWS S3 URL.

Thanks!