### PR TITLE
fix: use correct path for token file deletion in clearSessionData and logOutSession

### DIFF
--- a/src/controller/miscController.ts
+++ b/src/controller/miscController.ts
@@ -16,6 +16,7 @@
 
 import { Request, Response } from 'express';
 import fs from 'fs';
+import path from 'path';
 
 import { logger } from '..';
 import config from '../config';
@@ -160,10 +161,10 @@ export async function clearSessionData(req: Request, res: Response) {
       delete clientsArray[req.params.session];
       await req.client.logout();
     }
-    const path = config.customUserDataDir + session;
-    const pathToken = __dirname + `../../../tokens/${session}.data.json`;
-    if (fs.existsSync(path)) {
-      await fs.promises.rm(path, {
+    const pathUserData = config.customUserDataDir + session;
+    const pathToken = path.resolve(process.cwd(), 'tokens', `${session}.data.json`);
+    if (fs.existsSync(pathUserData)) {
+      await fs.promises.rm(pathUserData, {
         recursive: true,
       });
     }

--- a/src/controller/sessionController.ts
+++ b/src/controller/sessionController.ts
@@ -17,6 +17,7 @@ import { Message, Whatsapp } from '@wppconnect-team/wppconnect';
 import { Request, Response } from 'express';
 import fs from 'fs';
 import mime from 'mime-types';
+import path from 'path';
 import QRCode from 'qrcode';
 import { Logger } from 'winston';
 
@@ -300,7 +301,7 @@ export async function logOutSession(req: Request, res: Response): Promise<any> {
 
     setTimeout(async () => {
       const pathUserData = config.customUserDataDir + req.session;
-      const pathTokens = __dirname + `../../../tokens/${req.session}.data.json`;
+      const pathTokens = path.resolve(process.cwd(), 'tokens', `${req.session}.data.json`);
 
       if (fs.existsSync(pathUserData)) {
         await fs.promises.rm(pathUserData, {


### PR DESCRIPTION
## Summary

`clearSessionData` and `logOutSession` fail to delete token files from the `tokens/` directory due to incorrect path construction. This causes orphaned sessions to persist in `show-all-sessions` responses even after session data has been cleared.

### Bug

Both controllers use `__dirname + '../../../tokens/${session}.data.json'` to build the token file path. This has two issues:

1. **String concatenation without separator** — `__dirname` does not end with `/`, so the resulting path is malformed (e.g. `/opt/wppconnect-server/dist/controller../../../tokens/...`)
2. **Wrong number of `../`** — depending on whether the code runs from `src/` or `dist/`, three levels up may not resolve to the project root

Meanwhile, `FileTokenStore` already uses the correct approach: `path.resolve(process.cwd(), './tokens/')`.

### Fix

Replace `__dirname + '../../../tokens/...'` with `path.resolve(process.cwd(), 'tokens', ...)` in both:
- `src/controller/miscController.ts` (`clearSessionData`)
- `src/controller/sessionController.ts` (`logOutSession`)

Also fix variable shadowing in `clearSessionData` where `const path = config.customUserDataDir + session` shadows the `path` import.

### Impact

Without this fix, calling `clear-session-data` or `logout-session` removes the Chrome user data directory but **leaves the token file on disk**. On restart, `show-all-sessions` (via `getAllTokens`) still lists these ghost sessions and attempts to restore them — potentially spawning hundreds of unnecessary Chrome processes.

Tested on production with v2.9.0.

## Test plan

1. Start a session → verify token file exists in `tokens/`
2. Call `clear-session-data` → verify token file is deleted
3. Call `show-all-sessions` → verify session no longer appears
4. Restart server → verify no orphaned Chrome processes spawn