### PR TITLE
feat: add paginated status-stories endpoint and fix forward messages bug

### DIFF
--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -1003,12 +1003,13 @@ export async function forwardMessages(req: Request, res: Response) {
   const { phone, messageId, isGroup = false } = req.body;
 
   try {
+    const contacts = Array.isArray(phone)
+      ? phone
+      : contactToArray(phone, isGroup);
     let response;
 
-    if (!isGroup) {
-      response = await req.client.forwardMessagesV2(`${phone[0]}`, messageId);
-    } else {
-      response = await req.client.forwardMessagesV2(`${phone[0]}`, messageId);
+    for (const contato of contacts) {
+      response = await req.client.forwardMessagesV2(contato, messageId);
     }
 
     res.status(201).json({ status: 'success', response: response });

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -1003,9 +1003,7 @@ export async function forwardMessages(req: Request, res: Response) {
   const { phone, messageId, isGroup = false } = req.body;
 
   try {
-    const contacts = Array.isArray(phone)
-      ? phone
-      : contactToArray(phone, isGroup);
+    const contacts = contactToArray(phone, isGroup);
     let response;
 
     for (const contato of contacts) {

--- a/src/controller/statusController.ts
+++ b/src/controller/statusController.ts
@@ -203,8 +203,10 @@ export async function getStatusStories(req: Request, res: Response) {
       default: 20
      }
    */
-  const page = parseInt(req.query.page as string) || 1;
-  const limit = parseInt(req.query.limit as string) || 20;
+  const rawPage = Number.parseInt(req.query.page as string, 10);
+  const rawLimit = Number.parseInt(req.query.limit as string, 10);
+  const page = Number.isNaN(rawPage) || rawPage < 1 ? 1 : rawPage;
+  const limit = Number.isNaN(rawLimit) || rawLimit < 0 ? 20 : rawLimit;
 
   try {
     const response = await req.client.page.evaluate(
@@ -216,34 +218,47 @@ export async function getStatusStories(req: Request, res: Response) {
           !WPPLocal.whatsapp.StatusV3Store
         ) {
           return {
-            total: 0,
-            page: p,
-            limit: l,
-            pages: 0,
-            results: [],
+            error: true,
+            message: 'WPP is not initialized or StatusV3Store is unavailable',
           };
         }
 
         const models = WPPLocal.whatsapp.StatusV3Store.toArray();
-        let paginatedModels = models;
+        const total = models.length;
 
-        if (l > 0) {
-          const startIndex = (p - 1) * l;
-          const endIndex = p * l;
-          paginatedModels = models.slice(startIndex, endIndex);
+        if (l === 0) {
+          return {
+            total,
+            page: 1,
+            limit: 0,
+            pages: 1,
+            results: models.map((m: any) => m.toJSON()),
+          };
         }
 
+        const pages = Math.ceil(total / l) || 1;
+        const startIndex = (p - 1) * l;
+        const endIndex = p * l;
+        const paginatedModels = models.slice(startIndex, endIndex);
+
         return {
-          total: models.length,
-          page: l > 0 ? p : 1,
-          limit: l > 0 ? l : models.length,
-          pages: l > 0 ? Math.ceil(models.length / l) : 1,
+          total,
+          page: p,
+          limit: l,
+          pages,
           results: paginatedModels.map((m: any) => m.toJSON()),
         };
       },
       page,
       limit
     );
+
+    if (response?.error) {
+      return res.status(400).json({
+        status: 'error',
+        message: response.message || 'WPP is not initialized',
+      });
+    }
 
     res.status(200).json({ status: 'success', response: response });
   } catch (error) {

--- a/src/controller/statusController.ts
+++ b/src/controller/statusController.ts
@@ -179,3 +179,79 @@ export async function sendVideoStorie(req: Request, res: Response) {
     returnError(req, res, error);
   }
 }
+
+export async function getStatusStories(req: Request, res: Response) {
+  /**
+     #swagger.tags = ["Status Stories"]
+     #swagger.autoBody=false
+     #swagger.security = [{
+            "bearerAuth": []
+     }]
+     #swagger.parameters["session"] = {
+      schema: 'NERDWHATS_AMERICA'
+     }
+     #swagger.parameters["page"] = {
+      in: 'query',
+      type: 'integer',
+      description: 'Page number',
+      default: 1
+     }
+     #swagger.parameters["limit"] = {
+      in: 'query',
+      type: 'integer',
+      description: 'Items per page (0 to return all)',
+      default: 20
+     }
+   */
+  const page = parseInt(req.query.page as string) || 1;
+  const limit = parseInt(req.query.limit as string) || 20;
+
+  try {
+    const response = await req.client.page.evaluate(
+      (p, l) => {
+        const WPPLocal = (window as any).WPP;
+        if (
+          !WPPLocal ||
+          !WPPLocal.whatsapp ||
+          !WPPLocal.whatsapp.StatusV3Store
+        ) {
+          return {
+            total: 0,
+            page: p,
+            limit: l,
+            pages: 0,
+            results: [],
+          };
+        }
+
+        const models = WPPLocal.whatsapp.StatusV3Store.toArray();
+        let paginatedModels = models;
+
+        if (l > 0) {
+          const startIndex = (p - 1) * l;
+          const endIndex = p * l;
+          paginatedModels = models.slice(startIndex, endIndex);
+        }
+
+        return {
+          total: models.length,
+          page: l > 0 ? p : 1,
+          limit: l > 0 ? l : models.length,
+          pages: l > 0 ? Math.ceil(models.length / l) : 1,
+          results: paginatedModels.map((m: any) => m.toJSON()),
+        };
+      },
+      page,
+      limit
+    );
+
+    res.status(200).json({ status: 'success', response: response });
+  } catch (error) {
+    req.logger.error(error);
+    res.status(500).json({
+      status: 'error',
+      message: 'Error retrieving status stories',
+      error: error,
+    });
+  }
+}

--- a/src/middleware/statusConnection.ts
+++ b/src/middleware/statusConnection.ts
@@ -45,7 +45,7 @@ export default async function statusConnection(
             .catch((error) => console.log(error));
           if (!profile?.numberExists) {
             const num = (contact as any).split('@')[0];
-            res.status(400).json({
+            return res.status(400).json({
               response: null,
               status: 'Connected',
               message: `O número ${num} não existe.`,

--- a/src/middleware/statusConnection.ts
+++ b/src/middleware/statusConnection.ts
@@ -60,17 +60,17 @@ export default async function statusConnection(
         index++;
       }
       req.body.phone = localArr;
+      return next();
     } else {
-      res.status(404).json({
+      return res.status(404).json({
         response: null,
         status: 'Disconnected',
         message: 'A sessão do WhatsApp não está ativa.',
       });
     }
-    next();
   } catch (error) {
     req.logger.error(error);
-    res.status(404).json({
+    return res.status(404).json({
       response: null,
       status: 'Disconnected',
       message: 'A sessão do WhatsApp não está ativa.',

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -713,6 +713,12 @@ routes.post(
   statusConnection,
   StatusController.sendVideoStorie
 );
+routes.get(
+  '/api/:session/status-stories',
+  verifyToken,
+  statusConnection,
+  StatusController.getStatusStories
+);
 
 // Labels
 routes.post(


### PR DESCRIPTION
# Description

This PR introduces a new endpoint to retrieve all contacts' status updates (stories) with pagination, fixes the message forwarding bug, and resolves a double-header response issue in the `statusConnection` middleware.

## Proposed Changes

### 1. Paginated Contact Status/Stories Endpoint
- **New Endpoint**: `GET /api/:session/status-stories`
- **Query Parameters**:
  - `page` (default: `1`) - The page number to fetch.
  - `limit` (default: `20`) - The number of stories per page (pass `0` to retrieve all without pagination).
- **Implementation**: Evaluates the global `WPP.whatsapp.StatusV3Store` inside the Puppeteer page, slices the models arrays to implement pagination, and returns only the serialized data for the selected page.

### 2. Forward Messages Bug Fix
- **Modified**: `DeviceController.forwardMessages` (`POST /api/:session/forward-messages`)
- **Fix**: Formats the `phone` field using `contactToArray(phone, isGroup)` and iterates over the contacts array, forwarding the message to each target JID using `forwardMessagesV2`. This resolves the bug where only the first character of the phone number was forwarded.

### 3. Middleware Return Fix
- **Modified**: `statusConnection` middleware
- **Fix**: Added a missing `return` statement in the `!profile?.numberExists` check to prevent Express double header response errors (server crashes) when a phone number is invalid.

## Verification

- Verified TypeScript compilation using `npm run build:types` (completed with no errors).