### PR TITLE
feat: add experimental WhatsApp call media bridge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,12 @@ WORKDIR /usr/src/wpp-server/
 # Install runtime dependencies (chromium and vips libraries)
 RUN apk add --no-cache \
     chromium \
+    ffmpeg \
     vips \
-    fftw
+    fftw && \
+    ffmpeg -hide_banner -loglevel error \
+      -f lavfi -i anullsrc=r=48000:cl=mono \
+      -t 1 -c:a pcm_s16le /usr/src/wpp-server/silence.wav
 
 EXPOSE 21465
 ENTRYPOINT ["node", "dist/server.js"]

--- a/docs/whatsapp-call-media-bridge.md
+++ b/docs/whatsapp-call-media-bridge.md
@@ -30,6 +30,11 @@ Run the REST and Socket.IO endpoints behind TLS. A media ticket is a bearer
 credential during its short lifetime and must not appear in URLs, logs, or
 metrics.
 
+Tickets and active-call bindings are intentionally held in process memory. A
+multi-process or multi-node deployment must route ticket creation and the
+subsequent Socket.IO handshake to the same WPPConnect process (sticky routing),
+or replace the ticket registry with an atomic shared store.
+
 For outbound audio, emit `outgoing-audio` on the authenticated media socket:
 
 ```json

--- a/docs/whatsapp-call-media-bridge.md
+++ b/docs/whatsapp-call-media-bridge.md
@@ -8,18 +8,35 @@ explicitly creates signalling only; it does not attach audio or video tracks.
 Consequently, the HTTP endpoints in this branch must not report that a usable
 voice call exists until a media bridge has been implemented.
 
-This branch also contains an experimental phase-two receiver. Calling
+This branch also contains an experimental phase-two media bridge. Calling
 `POST /api/{session}/start-incoming-call-audio` before accepting a call
-instruments WebRTC and publishes chunks through the Socket.IO `call-audio`
-event. Each payload contains `session`, `mimeType`, Base64 `data`, `sequence`,
-and `timestamp`. Use
+instruments WebRTC and publishes chunks through the authenticated Socket.IO
+`/call-media` namespace's `incoming-audio` event. Each payload contains
+`mimeType`, Base64 `data`, `sequence`, and `timestamp`. Use
 `POST /api/{session}/stop-incoming-call-audio` to stop active recorders.
 
-This receiver is a proof of concept, not a production media endpoint. The
-server's existing Socket.IO connection is not authenticated or isolated into
-session rooms, so raw call audio could be observed by another connected socket.
-Production deployment requires a call-scoped authenticated namespace or a
-dedicated media gateway before this feature can be enabled by default.
+Create a short-lived connection ticket with
+`POST /api/{session}/call-media-ticket`, authenticated with the normal bearer
+token. Connect to `/call-media` with `auth: { ticket }`. Tickets are random,
+single-use, valid for at most five minutes, and bind the socket to one session
+room. Never put the normal session bearer token in a Socket.IO handshake.
+
+For outbound audio, emit `outgoing-audio` on the authenticated media socket:
+
+```json
+{
+  "data": "<base64 little-endian signed PCM16>",
+  "sampleRate": 48000
+}
+```
+
+The acknowledgement contains `attached: true` after the Web Audio track has
+replaced an existing audio sender. An `attached: false` response means that no
+active WebRTC connection/audio sender was available yet. Clients should send
+small timestamped chunks at their original cadence and use bounded queues.
+
+The bridge remains experimental. It must be validated against a real WhatsApp
+call and the exact pinned WhatsApp Web build before production use.
 
 ## Proposed architecture
 

--- a/docs/whatsapp-call-media-bridge.md
+++ b/docs/whatsapp-call-media-bridge.md
@@ -9,18 +9,22 @@ Consequently, the HTTP endpoints in this branch must not report that a usable
 voice call exists until a media bridge has been implemented.
 
 This branch also contains an experimental phase-two media bridge. Calling
-`POST /api/{session}/start-incoming-call-audio` before accepting a call
+`POST /api/{session}/start-incoming-call-audio` with the incoming `callId`
+before accepting a call
 instruments WebRTC and publishes signed little-endian PCM16 chunks through the
 authenticated Socket.IO `/call-media` namespace's `incoming-audio` event. Each
 payload contains `mimeType` (including the browser sample rate), Base64 `data`,
 `sequence`, and `timestamp`. Use
-`POST /api/{session}/stop-incoming-call-audio` to stop active recorders.
+`POST /api/{session}/stop-call-media` to tear down both media directions,
+invalidate unused tickets, and disconnect the call-scoped socket.
 
 Create a short-lived connection ticket with
-`POST /api/{session}/call-media-ticket`, authenticated with the normal bearer
-token. Connect to `/call-media` with `auth: { ticket }`. Tickets are random,
-single-use, valid for at most five minutes, and bind the socket to one session
-room. Never put the normal session bearer token in a Socket.IO handshake.
+`POST /api/{session}/call-media-ticket`, passing the same active `callId` and
+authenticating with the normal bearer token. Connect to `/call-media` with
+`auth: { ticket }`. Tickets are random, single-use, valid for at most five
+minutes, and bind the socket to exactly one session and call room. A ticket for
+an inactive or different call is rejected. Never put the normal session bearer
+token in a Socket.IO handshake.
 
 For outbound audio, emit `outgoing-audio` on the authenticated media socket:
 
@@ -31,13 +35,25 @@ For outbound audio, emit `outgoing-audio` on the authenticated media socket:
 }
 ```
 
-The acknowledgement contains `attached: true` after the Web Audio track has
+The acknowledgement contains the bound `callId` and `attached: true` after the Web Audio track has
 replaced an existing audio sender. An `attached: false` response means that no
 active WebRTC connection/audio sender was available yet. Clients should send
 small timestamped chunks at their original cadence and use bounded queues.
 
 The bridge remains experimental. It must be validated against a real WhatsApp
 call and the exact pinned WhatsApp Web build before production use.
+
+### Connection sequence
+
+1. Read `callId` from the existing incoming-call event.
+2. Call `start-incoming-call-audio` with `{ "callId": "..." }` before
+   accepting the call.
+3. Call `call-media-ticket` with the same `callId` and the normal REST bearer
+   token.
+4. Connect Socket.IO to `/call-media` with the returned ticket in `auth`.
+5. Subscribe to `incoming-audio`; emit PCM16 chunks through `outgoing-audio`.
+6. Accept the call. End it through `end-call`, which also tears down the media
+   bridge and disconnects the call-scoped socket.
 
 ## Proposed architecture
 

--- a/docs/whatsapp-call-media-bridge.md
+++ b/docs/whatsapp-call-media-bridge.md
@@ -1,0 +1,90 @@
+# WhatsApp call media bridge
+
+## Current scope
+
+The server can expose WhatsApp Web call signalling controls: enable the call
+interface, offer, accept, reject, and end a call. The WA-JS `call.offer` API
+explicitly creates signalling only; it does not attach audio or video tracks.
+Consequently, the HTTP endpoints in this branch must not report that a usable
+voice call exists until a media bridge has been implemented.
+
+## Proposed architecture
+
+Keep WhatsApp signalling and encryption inside the browser session. Add a
+per-call media bridge alongside each WPPConnect session:
+
+1. Install browser instrumentation before WhatsApp Web starts creating peer
+   connections. Observe `RTCPeerConnection` creation and its `track`,
+   `connectionstatechange`, and `iceconnectionstatechange` events.
+2. Capture the incoming remote audio track and forward encoded Opus frames (or
+   PCM during the prototype) to an authenticated WebSocket media endpoint.
+3. Receive outbound audio over that endpoint and inject it as a live
+   `MediaStreamTrack` into the WhatsApp peer connection.
+4. Associate the media channel with `session`, `callId`, direction, codec, and
+   sequence/timestamp metadata. Tear it down when the call ends or the browser
+   session disconnects.
+
+```text
+telephone / bot / SIP gateway
+             |
+       authenticated WebSocket
+             |
+       media bridge per call
+        |                |
+ incoming track     outgoing track
+        |                |
+     Chromium / WhatsApp Web / WebRTC
+```
+
+For production telephony, a sidecar can translate WebSocket media to RTP/SRTP
+and SIP. Opus at 48 kHz should remain encoded whenever possible to avoid extra
+latency and transcoding loss.
+
+## Required upstream work
+
+The clean implementation spans three projects:
+
+- WA-JS: a supported API for call lifecycle and access to incoming/outgoing
+  media tracks. Private WhatsApp modules are unstable and should be a fallback,
+  not the public contract.
+- WPPConnect library: typed client methods and events that wrap that WA-JS API.
+- WPPConnect Server: authenticated REST signalling endpoints plus the streaming
+  media endpoint, lifecycle management, limits, and observability.
+
+Direct `page.evaluate` calls are suitable for validating signalling in this
+server branch. Media interception should first be contributed at the WA-JS
+layer so it is installed early enough and remains reusable by other clients.
+
+## Prototype milestones
+
+1. Prove incoming audio capture in headed Chromium and persist a short test
+   recording.
+2. Prove outbound synthetic audio injection and confirm it is heard by the
+   remote participant.
+3. Replace files with a full-duplex authenticated WebSocket stream; implement
+   timestamps, jitter buffering, backpressure, and reconnect/teardown rules.
+4. Add headless Docker audio support and test CPU/memory use with concurrent
+   sessions.
+5. Add codec negotiation, optional RTP/SIP gateway support, metrics, and
+   end-to-end integration tests.
+
+## Risks and safeguards
+
+- WhatsApp private call internals can change without notice. Pin and test the
+  WhatsApp Web version used by each release.
+- Headless containers have no physical microphone or speaker; outbound and
+  inbound devices must be virtual or supplied directly as media tracks.
+- Audio endpoints need short-lived, call-scoped credentials and strict session
+  isolation. Never expose raw media through the normal bearer token alone.
+- Recording and processing calls may require participant consent and legal
+  controls depending on jurisdiction. Recording should be opt-in and encrypted
+  at rest.
+- Add timeouts and bounded queues so a slow media consumer cannot exhaust the
+  server.
+
+## Acceptance criteria for real audio support
+
+Audio transport is complete only when two external clients can exchange speech
+in both directions through the server for a sustained call, with deterministic
+cleanup, bounded latency, authenticated media access, and automated coverage in
+the supported Docker/headless environment.

--- a/docs/whatsapp-call-media-bridge.md
+++ b/docs/whatsapp-call-media-bridge.md
@@ -10,9 +10,10 @@ voice call exists until a media bridge has been implemented.
 
 This branch also contains an experimental phase-two media bridge. Calling
 `POST /api/{session}/start-incoming-call-audio` before accepting a call
-instruments WebRTC and publishes chunks through the authenticated Socket.IO
-`/call-media` namespace's `incoming-audio` event. Each payload contains
-`mimeType`, Base64 `data`, `sequence`, and `timestamp`. Use
+instruments WebRTC and publishes signed little-endian PCM16 chunks through the
+authenticated Socket.IO `/call-media` namespace's `incoming-audio` event. Each
+payload contains `mimeType` (including the browser sample rate), Base64 `data`,
+`sequence`, and `timestamp`. Use
 `POST /api/{session}/stop-incoming-call-audio` to stop active recorders.
 
 Create a short-lived connection ticket with

--- a/docs/whatsapp-call-media-bridge.md
+++ b/docs/whatsapp-call-media-bridge.md
@@ -8,6 +8,19 @@ explicitly creates signalling only; it does not attach audio or video tracks.
 Consequently, the HTTP endpoints in this branch must not report that a usable
 voice call exists until a media bridge has been implemented.
 
+This branch also contains an experimental phase-two receiver. Calling
+`POST /api/{session}/start-incoming-call-audio` before accepting a call
+instruments WebRTC and publishes chunks through the Socket.IO `call-audio`
+event. Each payload contains `session`, `mimeType`, Base64 `data`, `sequence`,
+and `timestamp`. Use
+`POST /api/{session}/stop-incoming-call-audio` to stop active recorders.
+
+This receiver is a proof of concept, not a production media endpoint. The
+server's existing Socket.IO connection is not authenticated or isolated into
+session rooms, so raw call audio could be observed by another connected socket.
+Production deployment requires a call-scoped authenticated namespace or a
+dedicated media gateway before this feature can be enabled by default.
+
 ## Proposed architecture
 
 Keep WhatsApp signalling and encryption inside the browser session. Add a

--- a/docs/whatsapp-call-media-bridge.md
+++ b/docs/whatsapp-call-media-bridge.md
@@ -68,6 +68,34 @@ call and the exact pinned WhatsApp Web build before production use.
 7. Accept the call. End it through `end-call`, which also tears down the media
    bridge and disconnects the call-scoped socket.
 
+### Live smoke test
+
+Prepare instrumentation immediately after the session connects:
+
+```bash
+WPP_URL=http://localhost:21466 \
+WPP_SESSION=my-session \
+WPP_TOKEN='<token>' \
+CALL_MEDIA_ACTION=prepare \
+yarn call-media:smoke
+```
+
+After `incomingcall` supplies its `callId`, start the bridge:
+
+```bash
+WPP_URL=http://localhost:21466 \
+WPP_SESSION=my-session \
+WPP_TOKEN='<token>' \
+WPP_CALL_ID='<call-id>' \
+INCOMING_PCM16_FILE=/tmp/incoming-call.pcm \
+yarn call-media:smoke
+```
+
+Set `OUTGOING_PCM16_FILE` and `OUTGOING_SAMPLE_RATE` to inject a headerless,
+mono, signed little-endian PCM16 file. Stop with `Ctrl+C`; the script reports
+received chunks/bytes and calls `stop-call-media`. Do not commit tokens or PCM
+recordings.
+
 ## Proposed architecture
 
 Keep WhatsApp signalling and encryption inside the browser session. Add a

--- a/docs/whatsapp-call-media-bridge.md
+++ b/docs/whatsapp-call-media-bridge.md
@@ -44,10 +44,12 @@ For outbound audio, emit `outgoing-audio` on the authenticated media socket:
 }
 ```
 
-The acknowledgement contains the bound `callId` and `attached: true` after the Web Audio track has
-replaced an existing audio sender. An `attached: false` response means that no
-active WebRTC connection/audio sender was available yet. Clients should send
-small timestamped chunks at their original cadence and use bounded queues.
+The acknowledgement contains the bound `callId` and `attached: true` after a
+generated media track has replaced an existing audio sender. Chromium uses
+`MediaStreamTrackGenerator` with paced 20 ms audio frames when available and a
+Web Audio bridge as a compatibility fallback. An `attached: false` response
+means that no active WebRTC connection/audio sender was available yet. Clients
+should send small chunks at their original cadence and use bounded queues.
 
 The bridge remains experimental. It must be validated against a real WhatsApp
 call and the exact pinned WhatsApp Web build before production use.

--- a/docs/whatsapp-call-media-bridge.md
+++ b/docs/whatsapp-call-media-bridge.md
@@ -26,6 +26,10 @@ minutes, and bind the socket to exactly one session and call room. A ticket for
 an inactive or different call is rejected. Never put the normal session bearer
 token in a Socket.IO handshake.
 
+Run the REST and Socket.IO endpoints behind TLS. A media ticket is a bearer
+credential during its short lifetime and must not appear in URLs, logs, or
+metrics.
+
 For outbound audio, emit `outgoing-audio` on the authenticated media socket:
 
 ```json
@@ -45,14 +49,18 @@ call and the exact pinned WhatsApp Web build before production use.
 
 ### Connection sequence
 
-1. Read `callId` from the existing incoming-call event.
-2. Call `start-incoming-call-audio` with `{ "callId": "..." }` before
+1. After the WPPConnect session becomes connected, call
+   `enable-call-interface` once. This installs the opt-in WebRTC instrumentation
+   before any peer connection is created; waiting for an incoming-call event
+   can be too late on some WhatsApp Web builds.
+2. Read `callId` from the existing incoming-call event.
+3. Call `start-incoming-call-audio` with `{ "callId": "..." }` before
    accepting the call.
-3. Call `call-media-ticket` with the same `callId` and the normal REST bearer
+4. Call `call-media-ticket` with the same `callId` and the normal REST bearer
    token.
-4. Connect Socket.IO to `/call-media` with the returned ticket in `auth`.
-5. Subscribe to `incoming-audio`; emit PCM16 chunks through `outgoing-audio`.
-6. Accept the call. End it through `end-call`, which also tears down the media
+5. Connect Socket.IO to `/call-media` with the returned ticket in `auth`.
+6. Subscribe to `incoming-audio`; emit PCM16 chunks through `outgoing-audio`.
+7. Accept the call. End it through `end-call`, which also tears down the media
    bridge and disconnects the call-scoped socket.
 
 ## Proposed architecture

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:types": "tsc",
     "build:js": "rimraf dist && babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline --copy-files",
     "build": "npm run build:types && npm run build:js",
+    "call-media:smoke": "node scripts/call-media-smoke.mjs",
     "changelog:last": "conventional-changelog -p angular -r 2",
     "changelog:preview": "conventional-changelog -p angular -u",
     "changelog:update": "conventional-changelog -p angular -i CHANGELOG.md -s",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "release-it": "^19.2.4",
     "rimraf": "^6.1.3",
     "shx": "^0.4.0",
+    "socket.io-client": "^4.8.3",
     "swagger-ui-dist": "^5.32.1",
     "ts-jest": "^29.4.6",
     "ts-loader": "^9.5.4",

--- a/scripts/call-media-smoke.mjs
+++ b/scripts/call-media-smoke.mjs
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createWriteStream, readFileSync } from 'node:fs';
+import { io } from 'socket.io-client';
+
+const baseUrl = process.env.WPP_URL?.replace(/\/$/, '');
+const session = process.env.WPP_SESSION;
+const token = process.env.WPP_TOKEN;
+const action = process.env.CALL_MEDIA_ACTION || 'bridge';
+const callId = process.env.WPP_CALL_ID;
+
+if (!baseUrl || !session || !token) {
+  throw new Error('WPP_URL, WPP_SESSION and WPP_TOKEN are required');
+}
+
+async function post(endpoint, body = {}) {
+  const response = await fetch(`${baseUrl}/api/${session}/${endpoint}`, {
+    body: JSON.stringify(body),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  });
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(
+      `${endpoint} failed (${response.status}): ${payload.message}`
+    );
+  }
+  return payload;
+}
+
+if (action === 'prepare') {
+  await post('enable-call-interface');
+  console.log('Call interface and media instrumentation are ready.');
+  process.exit(0);
+}
+
+if (!callId) throw new Error('WPP_CALL_ID is required for bridge mode');
+
+await post('start-incoming-call-audio', {
+  callId,
+  timesliceMs: Number(process.env.CALL_MEDIA_TIMESLICE_MS || 250),
+});
+const ticketResponse = await post('call-media-ticket', { callId });
+const ticket = ticketResponse.response.ticket;
+const socket = io(`${baseUrl}/call-media`, {
+  auth: { ticket },
+  reconnection: false,
+  transports: ['websocket'],
+});
+
+const output = process.env.INCOMING_PCM16_FILE
+  ? createWriteStream(process.env.INCOMING_PCM16_FILE)
+  : undefined;
+let incomingBytes = 0;
+let incomingChunks = 0;
+
+socket.on('incoming-audio', (chunk) => {
+  if (chunk.callId !== callId) return;
+  const bytes = Buffer.from(chunk.data, 'base64');
+  incomingBytes += bytes.length;
+  incomingChunks++;
+  output?.write(bytes);
+  if (incomingChunks % 20 === 0) {
+    console.log(
+      `incoming callId=${callId} chunks=${incomingChunks} bytes=${incomingBytes} ${chunk.mimeType}`
+    );
+  }
+});
+
+socket.on('connect_error', (error) => {
+  console.error(`Media connection failed: ${error.message}`);
+  process.exitCode = 1;
+});
+
+socket.on('connect', () => {
+  console.log(`Media connected for callId=${callId}`);
+  const filename = process.env.OUTGOING_PCM16_FILE;
+  if (!filename) return;
+
+  const sampleRate = Number(process.env.OUTGOING_SAMPLE_RATE || 24_000);
+  const audio = readFileSync(filename);
+  const bytesPer20Ms = Math.round((sampleRate * 2) / 50);
+  let offset = 0;
+  const timer = setInterval(() => {
+    if (!socket.connected || offset >= audio.length) {
+      clearInterval(timer);
+      return;
+    }
+    const data = audio.subarray(offset, offset + bytesPer20Ms);
+    offset += data.length;
+    socket.emit(
+      'outgoing-audio',
+      { data: data.toString('base64'), sampleRate },
+      (acknowledgement) => {
+        if (!acknowledgement?.attached) {
+          console.error(
+            `Outgoing audio was not attached: ${
+              acknowledgement?.error || 'no active audio sender'
+            }`
+          );
+        }
+      }
+    );
+  }, 20);
+});
+
+async function shutdown() {
+  socket.close();
+  output?.end();
+  try {
+    await post('stop-call-media');
+  } finally {
+    console.log(
+      `Media stopped callId=${callId} chunks=${incomingChunks} bytes=${incomingBytes}`
+    );
+  }
+}
+
+process.once('SIGINT', () => void shutdown().finally(() => process.exit()));
+process.once('SIGTERM', () => void shutdown().finally(() => process.exit()));

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,9 @@ export default {
     logger: ['console', 'file'],
   },
   createOptions: {
+    puppeteerOptions: {
+      ignoreDefaultArgs: ['--mute-audio'],
+    },
     browserArgs: [
       '--disable-web-security',
       '--no-sandbox',
@@ -62,7 +65,10 @@ export default {
       '--disable-translate',
       '--hide-scrollbars',
       '--metrics-recording-only',
-      '--mute-audio',
+      '--use-fake-ui-for-media-stream',
+      '--use-fake-device-for-media-stream',
+      '--use-file-for-fake-audio-capture=/usr/src/wpp-server/silence.wav',
+      '--enable-features=SharedArrayBuffer',
       '--no-first-run',
       '--safebrowsing-disable-auto-update',
       '--ignore-certificate-errors',

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -2121,10 +2121,17 @@ export async function enableCallInterface(req: Request, res: Response) {
      #swagger.tags = ["Calls"]
      #swagger.description = "Enables the WhatsApp Web call interface for the current session."
      #swagger.security = [{ "bearerAuth": [] }]
-   */
+  */
   try {
+    await CallUtil.installIncomingAudioCapture(req.client.page, () => {
+      // The call-scoped handler is registered by startIncomingCallAudio.
+    });
     await CallUtil.enableCallInterface(req.client.page);
-    res.status(200).json({ status: 'success', response: true });
+    res.status(200).json({
+      status: 'success',
+      response: true,
+      mediaInstrumentationReady: true,
+    });
   } catch (e) {
     req.logger.error(e);
     res.status(500).json({

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -2130,10 +2130,14 @@ export async function enableCallInterface(req: Request, res: Response) {
     });
     await CallUtil.installIncomingAudioCapture(req.client.page);
     await CallUtil.enableCallInterface(req.client.page);
+    const diagnostics = await CallUtil.getCallInterfaceDiagnostics(
+      req.client.page
+    );
     res.status(200).json({
       status: 'success',
       response: true,
       mediaInstrumentationReady: true,
+      diagnostics,
     });
   } catch (e) {
     req.logger.error(e);

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -20,6 +20,7 @@ import {
   activateCallMedia,
   createMediaTicket,
   deactivateCallMedia,
+  emitCallMediaEnded,
   emitIncomingAudio,
 } from '../util/callMediaUtil';
 import * as CallUtil from '../util/callUtil';
@@ -2283,13 +2284,17 @@ export async function startIncomingCallAudio(req: Request, res: Response) {
       (chunk) => {
         emitIncomingAudio(req.session, callId, chunk);
       },
-      { timesliceMs: parsedTimeslice }
+      { timesliceMs: parsedTimeslice },
+      () => {
+        emitCallMediaEnded(req.session, callId);
+      }
     );
     res.status(200).json({
       status: 'success',
       response: true,
       namespace: '/call-media',
       event: 'incoming-audio',
+      endedEvent: 'call-media-ended',
       mediaDirection: 'incoming',
       experimental: true,
       callId,

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -24,7 +24,7 @@ import {
   emitIncomingAudio,
 } from '../util/callMediaUtil';
 import * as CallUtil from '../util/callUtil';
-import { contactToArray, unlinkAsync } from '../util/functions';
+import { callWebHook, contactToArray, unlinkAsync } from '../util/functions';
 import { clientsArray } from '../util/sessionUtil';
 
 function returnSucess(res: any, session: any, phone: any, data: any) {
@@ -2124,6 +2124,10 @@ export async function enableCallInterface(req: Request, res: Response) {
      #swagger.security = [{ "bearerAuth": [] }]
   */
   try {
+    await CallUtil.installIncomingCallWatcher(req.client.page, (call) => {
+      req.io.emit('incomingcall', call);
+      void callWebHook(req.client, req, 'incomingcall', call);
+    });
     await CallUtil.installIncomingAudioCapture(req.client.page);
     await CallUtil.enableCallInterface(req.client.page);
     res.status(200).json({

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -2225,6 +2225,64 @@ export async function offerCall(req: Request, res: Response) {
   }
 }
 
+export async function startIncomingCallAudio(req: Request, res: Response) {
+  /**
+     #swagger.tags = ["Calls"]
+     #swagger.description = "Experimental: captures incoming WebRTC call audio and emits call-audio chunks through Socket.IO. Start before accepting the call."
+     #swagger.security = [{ "bearerAuth": [] }]
+   */
+  const { timesliceMs = 250 } = req.body || {};
+  const parsedTimeslice = Number(timesliceMs);
+  if (!Number.isFinite(parsedTimeslice) || parsedTimeslice < 100) {
+    res.status(400).json({
+      status: 'error',
+      message: 'timesliceMs must be a number greater than or equal to 100',
+    });
+    return;
+  }
+
+  try {
+    await CallUtil.installIncomingAudioCapture(
+      req.client.page,
+      (chunk) => {
+        req.io.emit('call-audio', { session: req.session, ...chunk });
+      },
+      { timesliceMs: parsedTimeslice }
+    );
+    res.status(200).json({
+      status: 'success',
+      response: true,
+      event: 'call-audio',
+      mediaDirection: 'incoming',
+      experimental: true,
+    });
+  } catch (e) {
+    req.logger.error(e);
+    res.status(500).json({
+      status: 'error',
+      message: 'Error on startIncomingCallAudio',
+    });
+  }
+}
+
+export async function stopIncomingCallAudio(req: Request, res: Response) {
+  /**
+     #swagger.tags = ["Calls"]
+     #swagger.description = "Stops all experimental incoming call audio recorders for the session."
+     #swagger.security = [{ "bearerAuth": [] }]
+   */
+  try {
+    await CallUtil.stopIncomingAudioCapture(req.client.page);
+    res.status(200).json({ status: 'success', response: true });
+  } catch (e) {
+    req.logger.error(e);
+    res.status(500).json({
+      status: 'error',
+      message: 'Error on stopIncomingCallAudio',
+    });
+  }
+}
+
 export async function starMessage(req: Request, res: Response) {
   /**
      #swagger.tags = ["Messages"]

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -2174,6 +2174,10 @@ export async function endCall(req: Request, res: Response) {
   const { callId } = req.body || {};
   try {
     const response = await CallUtil.endCall(req.client.page, callId);
+    await Promise.allSettled([
+      CallUtil.stopIncomingAudioCapture(req.client.page),
+      CallUtil.stopOutgoingAudio(req.client.page),
+    ]);
     res.status(200).json({ status: 'success', response });
   } catch (e) {
     req.logger.error(e);
@@ -2288,7 +2292,10 @@ export async function stopIncomingCallAudio(req: Request, res: Response) {
      #swagger.security = [{ "bearerAuth": [] }]
    */
   try {
-    await CallUtil.stopIncomingAudioCapture(req.client.page);
+    await Promise.all([
+      CallUtil.stopIncomingAudioCapture(req.client.page),
+      CallUtil.stopOutgoingAudio(req.client.page),
+    ]);
     res.status(200).json({ status: 'success', response: true });
   } catch (e) {
     req.logger.error(e);

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -16,6 +16,7 @@
 import { Chat } from '@wppconnect-team/wppconnect';
 import { Request, Response } from 'express';
 
+import * as CallUtil from '../util/callUtil';
 import { contactToArray, unlinkAsync } from '../util/functions';
 import { clientsArray } from '../util/sessionUtil';
 
@@ -2106,6 +2107,121 @@ export async function rejectCall(req: Request, res: Response) {
     res
       .status(500)
       .json({ status: 'error', message: 'Error on rejectCall', error: e });
+  }
+}
+
+export async function enableCallInterface(req: Request, res: Response) {
+  /**
+     #swagger.tags = ["Calls"]
+     #swagger.description = "Enables the WhatsApp Web call interface for the current session."
+     #swagger.security = [{ "bearerAuth": [] }]
+   */
+  try {
+    await CallUtil.enableCallInterface(req.client.page);
+    res.status(200).json({ status: 'success', response: true });
+  } catch (e) {
+    req.logger.error(e);
+    res.status(500).json({
+      status: 'error',
+      message: 'Error on enableCallInterface',
+    });
+  }
+}
+
+export async function acceptCall(req: Request, res: Response) {
+  /**
+     #swagger.tags = ["Calls"]
+     #swagger.security = [{ "bearerAuth": [] }]
+     #swagger.requestBody = {
+       required: false,
+       "@content": {
+         "application/json": {
+           schema: {
+             type: "object",
+             properties: { callId: { type: "string" } }
+           }
+         }
+       }
+     }
+   */
+  const { callId } = req.body || {};
+  try {
+    const response = await CallUtil.acceptCall(req.client.page, callId);
+    res.status(200).json({ status: 'success', response });
+  } catch (e) {
+    req.logger.error(e);
+    res.status(500).json({ status: 'error', message: 'Error on acceptCall' });
+  }
+}
+
+export async function endCall(req: Request, res: Response) {
+  /**
+     #swagger.tags = ["Calls"]
+     #swagger.security = [{ "bearerAuth": [] }]
+     #swagger.requestBody = {
+       required: false,
+       "@content": {
+         "application/json": {
+           schema: {
+             type: "object",
+             properties: { callId: { type: "string" } }
+           }
+         }
+       }
+     }
+   */
+  const { callId } = req.body || {};
+  try {
+    const response = await CallUtil.endCall(req.client.page, callId);
+    res.status(200).json({ status: 'success', response });
+  } catch (e) {
+    req.logger.error(e);
+    res.status(500).json({ status: 'error', message: 'Error on endCall' });
+  }
+}
+
+export async function offerCall(req: Request, res: Response) {
+  /**
+     #swagger.tags = ["Calls"]
+     #swagger.description = "Sends a WhatsApp call signalling offer. This endpoint does not transport audio or video media."
+     #swagger.security = [{ "bearerAuth": [] }]
+     #swagger.requestBody = {
+       required: true,
+       "@content": {
+         "application/json": {
+           schema: {
+             type: "object",
+             required: ["phone"],
+             properties: {
+               phone: { type: "string" },
+               isVideo: { type: "boolean", default: false }
+             }
+           }
+         }
+       }
+     }
+   */
+  const { phone, isVideo = false } = req.body || {};
+  if (typeof phone !== 'string' || !phone.trim()) {
+    res
+      .status(400)
+      .json({ status: 'error', message: 'Parameter phone is required!' });
+    return;
+  }
+
+  try {
+    const response = await CallUtil.offerCall(req.client.page, phone, {
+      isVideo: Boolean(isVideo),
+    });
+    res.status(200).json({
+      status: 'success',
+      response,
+      mediaTransport: false,
+      message: 'Call offer sent without audio/video media transport',
+    });
+  } catch (e) {
+    req.logger.error(e);
+    res.status(500).json({ status: 'error', message: 'Error on offerCall' });
   }
 }
 

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -16,6 +16,7 @@
 import { Chat } from '@wppconnect-team/wppconnect';
 import { Request, Response } from 'express';
 
+import { createMediaTicket, emitIncomingAudio } from '../util/callMediaUtil';
 import * as CallUtil from '../util/callUtil';
 import { contactToArray, unlinkAsync } from '../util/functions';
 import { clientsArray } from '../util/sessionUtil';
@@ -2245,14 +2246,15 @@ export async function startIncomingCallAudio(req: Request, res: Response) {
     await CallUtil.installIncomingAudioCapture(
       req.client.page,
       (chunk) => {
-        req.io.emit('call-audio', { session: req.session, ...chunk });
+        emitIncomingAudio(req.session, chunk);
       },
       { timesliceMs: parsedTimeslice }
     );
     res.status(200).json({
       status: 'success',
       response: true,
-      event: 'call-audio',
+      namespace: '/call-media',
+      event: 'incoming-audio',
       mediaDirection: 'incoming',
       experimental: true,
     });
@@ -2263,6 +2265,20 @@ export async function startIncomingCallAudio(req: Request, res: Response) {
       message: 'Error on startIncomingCallAudio',
     });
   }
+}
+
+export async function createCallMediaTicket(req: Request, res: Response) {
+  /**
+     #swagger.tags = ["Calls"]
+     #swagger.description = "Creates a short-lived, single-use ticket for the authenticated call media Socket.IO namespace."
+     #swagger.security = [{ "bearerAuth": [] }]
+   */
+  const { ttlMs = 60_000 } = req.body || {};
+  const result = createMediaTicket(req.session, Number(ttlMs));
+  res.status(200).json({
+    status: 'success',
+    response: { ...result, namespace: '/call-media' },
+  });
 }
 
 export async function stopIncomingCallAudio(req: Request, res: Response) {

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -2123,9 +2123,7 @@ export async function enableCallInterface(req: Request, res: Response) {
      #swagger.security = [{ "bearerAuth": [] }]
   */
   try {
-    await CallUtil.installIncomingAudioCapture(req.client.page, () => {
-      // The call-scoped handler is registered by startIncomingCallAudio.
-    });
+    await CallUtil.installIncomingAudioCapture(req.client.page);
     await CallUtil.enableCallInterface(req.client.page);
     res.status(200).json({
       status: 'success',
@@ -2185,7 +2183,7 @@ export async function endCall(req: Request, res: Response) {
    */
   const { callId } = req.body || {};
   try {
-    const response = await CallUtil.endCall(req.client.page, callId);
+    const response = await CallUtil.endCall(req.client.page);
     await Promise.allSettled([
       CallUtil.stopIncomingAudioCapture(req.client.page),
       CallUtil.stopOutgoingAudio(req.client.page),

--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -16,7 +16,12 @@
 import { Chat } from '@wppconnect-team/wppconnect';
 import { Request, Response } from 'express';
 
-import { createMediaTicket, emitIncomingAudio } from '../util/callMediaUtil';
+import {
+  activateCallMedia,
+  createMediaTicket,
+  deactivateCallMedia,
+  emitIncomingAudio,
+} from '../util/callMediaUtil';
 import * as CallUtil from '../util/callUtil';
 import { contactToArray, unlinkAsync } from '../util/functions';
 import { clientsArray } from '../util/sessionUtil';
@@ -2178,6 +2183,7 @@ export async function endCall(req: Request, res: Response) {
       CallUtil.stopIncomingAudioCapture(req.client.page),
       CallUtil.stopOutgoingAudio(req.client.page),
     ]);
+    deactivateCallMedia(req.session, callId);
     res.status(200).json({ status: 'success', response });
   } catch (e) {
     req.logger.error(e);
@@ -2233,10 +2239,29 @@ export async function offerCall(req: Request, res: Response) {
 export async function startIncomingCallAudio(req: Request, res: Response) {
   /**
      #swagger.tags = ["Calls"]
-     #swagger.description = "Experimental: captures incoming WebRTC call audio and emits call-audio chunks through Socket.IO. Start before accepting the call."
+     #swagger.description = "Experimental: captures incoming WebRTC call audio and emits PCM16 chunks through the authenticated /call-media Socket.IO namespace. Start before accepting the call."
      #swagger.security = [{ "bearerAuth": [] }]
+     #swagger.requestBody = {
+       required: true,
+       "@content": {
+         "application/json": {
+           schema: {
+             type: "object",
+             required: ["callId"],
+             properties: {
+               callId: { type: "string" },
+               timesliceMs: { type: "number", minimum: 100, default: 250 }
+             }
+           }
+         }
+       }
+     }
    */
-  const { timesliceMs = 250 } = req.body || {};
+  const { callId, timesliceMs = 250 } = req.body || {};
+  if (typeof callId !== 'string' || !callId.trim()) {
+    res.status(400).json({ status: 'error', message: 'callId is required' });
+    return;
+  }
   const parsedTimeslice = Number(timesliceMs);
   if (!Number.isFinite(parsedTimeslice) || parsedTimeslice < 100) {
     res.status(400).json({
@@ -2247,10 +2272,11 @@ export async function startIncomingCallAudio(req: Request, res: Response) {
   }
 
   try {
+    activateCallMedia(req.session, callId);
     await CallUtil.installIncomingAudioCapture(
       req.client.page,
       (chunk) => {
-        emitIncomingAudio(req.session, chunk);
+        emitIncomingAudio(req.session, callId, chunk);
       },
       { timesliceMs: parsedTimeslice }
     );
@@ -2261,8 +2287,10 @@ export async function startIncomingCallAudio(req: Request, res: Response) {
       event: 'incoming-audio',
       mediaDirection: 'incoming',
       experimental: true,
+      callId,
     });
   } catch (e) {
+    deactivateCallMedia(req.session, callId);
     req.logger.error(e);
     res.status(500).json({
       status: 'error',
@@ -2276,19 +2304,45 @@ export async function createCallMediaTicket(req: Request, res: Response) {
      #swagger.tags = ["Calls"]
      #swagger.description = "Creates a short-lived, single-use ticket for the authenticated call media Socket.IO namespace."
      #swagger.security = [{ "bearerAuth": [] }]
+     #swagger.requestBody = {
+       required: true,
+       "@content": {
+         "application/json": {
+           schema: {
+             type: "object",
+             required: ["callId"],
+             properties: {
+               callId: { type: "string" },
+               ttlMs: { type: "number", minimum: 1000, maximum: 300000, default: 60000 }
+             }
+           }
+         }
+       }
+     }
    */
-  const { ttlMs = 60_000 } = req.body || {};
-  const result = createMediaTicket(req.session, Number(ttlMs));
-  res.status(200).json({
-    status: 'success',
-    response: { ...result, namespace: '/call-media' },
-  });
+  const { callId, ttlMs = 60_000 } = req.body || {};
+  if (typeof callId !== 'string' || !callId.trim()) {
+    res.status(400).json({ status: 'error', message: 'callId is required' });
+    return;
+  }
+  try {
+    const result = createMediaTicket(req.session, callId, Number(ttlMs));
+    res.status(200).json({
+      status: 'success',
+      response: { ...result, callId, namespace: '/call-media' },
+    });
+  } catch (error) {
+    res.status(409).json({
+      status: 'error',
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
-export async function stopIncomingCallAudio(req: Request, res: Response) {
+export async function stopCallMedia(req: Request, res: Response) {
   /**
      #swagger.tags = ["Calls"]
-     #swagger.description = "Stops all experimental incoming call audio recorders for the session."
+     #swagger.description = "Stops incoming and outgoing call audio, invalidates tickets, and disconnects the active media socket for the session."
      #swagger.security = [{ "bearerAuth": [] }]
    */
   try {
@@ -2296,12 +2350,13 @@ export async function stopIncomingCallAudio(req: Request, res: Response) {
       CallUtil.stopIncomingAudioCapture(req.client.page),
       CallUtil.stopOutgoingAudio(req.client.page),
     ]);
+    deactivateCallMedia(req.session);
     res.status(200).json({ status: 'success', response: true });
   } catch (e) {
     req.logger.error(e);
     res.status(500).json({
       status: 'error',
-      message: 'Error on stopIncomingCallAudio',
+      message: 'Error on stopCallMedia',
     });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,17 @@ import { convert } from './mapper/index';
 import routes from './routes';
 import { ServerOptions } from './types/ServerOptions';
 import {
+  consumeMediaTicket,
+  setCallMediaNamespace,
+} from './util/callMediaUtil';
+import { pushOutgoingPcm16 } from './util/callUtil';
+import {
   createFolders,
   setMaxListners,
   startAllSessions,
 } from './util/functions';
 import { createLogger } from './util/logger';
+import { clientsArray } from './util/sessionUtil';
 
 //require('dotenv').config();
 
@@ -114,6 +120,44 @@ export function initServer(serverOptions: Partial<ServerOptions>): {
     sock.on('disconnect', () => {
       logger.info(`ID: ${sock.id} saiu`);
     });
+  });
+
+  const callMedia = io.of('/call-media');
+  setCallMediaNamespace(callMedia);
+  callMedia.use((socket, next) => {
+    const ticket = String(socket.handshake.auth?.ticket || '');
+    const authorization = consumeMediaTicket(ticket);
+    if (!authorization)
+      return next(new Error('Invalid or expired media ticket'));
+    socket.data.session = authorization.session;
+    next();
+  });
+  callMedia.on('connection', (socket) => {
+    const session = String(socket.data.session);
+    socket.join(session);
+    socket.on(
+      'outgoing-audio',
+      async (payload: { data?: string; sampleRate?: number }, acknowledge) => {
+        try {
+          const client = clientsArray[session];
+          if (!client?.page) throw new Error('Session is not connected');
+          const attached = await pushOutgoingPcm16(
+            client.page,
+            String(payload?.data || ''),
+            Number(payload?.sampleRate || 48_000)
+          );
+          if (typeof acknowledge === 'function') acknowledge({ attached });
+        } catch (error) {
+          logger.error(error);
+          if (typeof acknowledge === 'function') {
+            acknowledge({
+              attached: false,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }
+      }
+    );
   });
 
   http.listen(PORT, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,8 @@ import { convert } from './mapper/index';
 import routes from './routes';
 import { ServerOptions } from './types/ServerOptions';
 import {
-  consumeMediaTicket,
-  setCallMediaNamespace,
+  configureCallMediaNamespace,
+  isCallMediaActive,
 } from './util/callMediaUtil';
 import { pushOutgoingPcm16 } from './util/callUtil';
 import {
@@ -123,22 +123,17 @@ export function initServer(serverOptions: Partial<ServerOptions>): {
   });
 
   const callMedia = io.of('/call-media');
-  setCallMediaNamespace(callMedia);
-  callMedia.use((socket, next) => {
-    const ticket = String(socket.handshake.auth?.ticket || '');
-    const authorization = consumeMediaTicket(ticket);
-    if (!authorization)
-      return next(new Error('Invalid or expired media ticket'));
-    socket.data.session = authorization.session;
-    next();
-  });
+  configureCallMediaNamespace(callMedia);
   callMedia.on('connection', (socket) => {
     const session = String(socket.data.session);
-    socket.join(session);
+    const callId = String(socket.data.callId);
     socket.on(
       'outgoing-audio',
       async (payload: { data?: string; sampleRate?: number }, acknowledge) => {
         try {
+          if (!isCallMediaActive(session, callId)) {
+            throw new Error('Call media is no longer active');
+          }
           const client = clientsArray[session];
           if (!client?.page) throw new Error('Session is not connected');
           const attached = await pushOutgoingPcm16(
@@ -146,12 +141,14 @@ export function initServer(serverOptions: Partial<ServerOptions>): {
             String(payload?.data || ''),
             Number(payload?.sampleRate || 48_000)
           );
-          if (typeof acknowledge === 'function') acknowledge({ attached });
+          if (typeof acknowledge === 'function')
+            acknowledge({ attached, callId });
         } catch (error) {
           logger.error(error);
           if (typeof acknowledge === 'function') {
             acknowledge({
               attached: false,
+              callId,
               error: error instanceof Error ? error.message : String(error),
             });
           }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -623,6 +623,18 @@ routes.post(
   statusConnection,
   DeviceController.offerCall
 );
+routes.post(
+  '/api/:session/start-incoming-call-audio',
+  verifyToken,
+  statusConnection,
+  DeviceController.startIncomingCallAudio
+);
+routes.post(
+  '/api/:session/stop-incoming-call-audio',
+  verifyToken,
+  statusConnection,
+  DeviceController.stopIncomingCallAudio
+);
 
 // Catalog
 routes.get(

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -636,10 +636,10 @@ routes.post(
   DeviceController.createCallMediaTicket
 );
 routes.post(
-  '/api/:session/stop-incoming-call-audio',
+  '/api/:session/stop-call-media',
   verifyToken,
   statusConnection,
-  DeviceController.stopIncomingCallAudio
+  DeviceController.stopCallMedia
 );
 
 // Catalog

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -630,6 +630,12 @@ routes.post(
   DeviceController.startIncomingCallAudio
 );
 routes.post(
+  '/api/:session/call-media-ticket',
+  verifyToken,
+  statusConnection,
+  DeviceController.createCallMediaTicket
+);
+routes.post(
   '/api/:session/stop-incoming-call-audio',
   verifyToken,
   statusConnection,

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -599,6 +599,30 @@ routes.post(
   statusConnection,
   DeviceController.rejectCall
 );
+routes.post(
+  '/api/:session/enable-call-interface',
+  verifyToken,
+  statusConnection,
+  DeviceController.enableCallInterface
+);
+routes.post(
+  '/api/:session/accept-call',
+  verifyToken,
+  statusConnection,
+  DeviceController.acceptCall
+);
+routes.post(
+  '/api/:session/end-call',
+  verifyToken,
+  statusConnection,
+  DeviceController.endCall
+);
+routes.post(
+  '/api/:session/offer-call',
+  verifyToken,
+  statusConnection,
+  DeviceController.offerCall
+);
 
 // Catalog
 routes.get(

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -54,9 +54,7 @@
   "paths": {
     "/api/{session}/{secretkey}/generate-token": {
       "post": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "description": "",
         "parameters": [
           {
@@ -93,9 +91,7 @@
     },
     "/api/{secretkey}/show-all-sessions": {
       "get": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "description": "",
         "operationId": "showAllSessions",
         "parameters": [
@@ -126,9 +122,7 @@
     },
     "/api/{secretkey}/start-all": {
       "post": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "description": "",
         "operationId": "startAllSessions",
         "parameters": [
@@ -174,9 +168,7 @@
     },
     "/api/{session}/check-connection-session": {
       "get": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "description": "",
         "operationId": "CheckConnectionState",
         "parameters": [
@@ -204,9 +196,7 @@
     },
     "/api/{session}/get-media-by-message/{messageId}": {
       "get": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "operationId": "getMediaByMessage",
         "parameters": [
@@ -248,9 +238,7 @@
     },
     "/api/{session}/get-platform-from-message/{messageId}": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -289,9 +277,7 @@
     },
     "/api/{session}/qrcode-session": {
       "get": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "description": "",
         "operationId": "getQrCode",
         "parameters": [
@@ -322,9 +308,7 @@
     },
     "/api/{session}/start-session": {
       "post": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "description": "",
         "operationId": "startSession",
         "parameters": [
@@ -393,9 +377,7 @@
     },
     "/api/{session}/logout-session": {
       "post": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "description": "This route logout and delete session data",
         "operationId": "logoutSession",
         "parameters": [
@@ -426,9 +408,7 @@
     },
     "/api/{session}/{secretkey}/clear-session-data": {
       "post": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -465,9 +445,7 @@
     },
     "/api/{session}/close-session": {
       "post": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "description": "",
         "operationId": "closeSession",
         "parameters": [
@@ -498,9 +476,7 @@
     },
     "/api/{session}/subscribe-presence": {
       "post": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "operationId": "subscribePresence",
         "parameters": [
@@ -557,9 +533,7 @@
     },
     "/api/{session}/set-online-presence": {
       "post": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "operationId": "setOnlinePresence",
         "parameters": [
@@ -608,9 +582,7 @@
     },
     "/api/{session}/download-media": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "operationId": "downloadMediabyMessage",
         "parameters": [
@@ -659,9 +631,7 @@
     },
     "/api/{session}/send-message": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -748,9 +718,7 @@
     },
     "/api/{session}/edit-message": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -806,9 +774,7 @@
     },
     "/api/{session}/send-image": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -884,9 +850,7 @@
     },
     "/api/{session}/send-sticker": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -929,10 +893,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "phone",
-                  "path"
-                ]
+                "required": ["phone", "path"]
               },
               "examples": {
                 "Default": {
@@ -950,9 +911,7 @@
     },
     "/api/{session}/send-sticker-gif": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -995,10 +954,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "phone",
-                  "path"
-                ]
+                "required": ["phone", "path"]
               },
               "examples": {
                 "Default": {
@@ -1016,9 +972,7 @@
     },
     "/api/{session}/send-reply": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1079,9 +1033,7 @@
     },
     "/api/{session}/send-file": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1157,9 +1109,7 @@
     },
     "/api/{session}/send-file-base64": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1235,9 +1185,7 @@
     },
     "/api/{session}/send-voice": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1298,9 +1246,7 @@
     },
     "/api/{session}/send-voice-base64": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1357,9 +1303,7 @@
     },
     "/api/{session}/status-session": {
       "get": {
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "description": "",
         "operationId": "closeSession",
         "parameters": [
@@ -1390,9 +1334,7 @@
     },
     "/api/{session}/send-status": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1435,11 +1377,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "phone",
-                  "isGroup",
-                  "message"
-                ]
+                "required": ["phone", "isGroup", "message"]
               },
               "examples": {
                 "Default": {
@@ -1458,9 +1396,7 @@
     },
     "/api/{session}/send-link-preview": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1521,9 +1457,7 @@
     },
     "/api/{session}/send-location": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1592,9 +1526,7 @@
     },
     "/api/{session}/send-mentioned": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1643,11 +1575,7 @@
                     }
                   }
                 },
-                "required": [
-                  "phone",
-                  "message",
-                  "mentioned"
-                ]
+                "required": ["phone", "message", "mentioned"]
               },
               "examples": {
                 "Default": {
@@ -1655,9 +1583,7 @@
                     "phone": "groupId@g.us",
                     "isGroup": true,
                     "message": "Your text message",
-                    "mentioned": [
-                      "556593077171@c.us"
-                    ]
+                    "mentioned": ["556593077171@c.us"]
                   }
                 }
               }
@@ -1668,9 +1594,7 @@
     },
     "/api/{session}/send-buttons": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1698,9 +1622,7 @@
     },
     "/api/{session}/send-list-message": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1781,9 +1703,7 @@
     },
     "/api/{session}/send-order-message": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1889,9 +1809,7 @@
     },
     "/api/{session}/send-poll-message": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1944,11 +1862,7 @@
                     "phone": "5521999999999",
                     "isGroup": false,
                     "name": "Poll name",
-                    "choices": [
-                      "Option 1",
-                      "Option 2",
-                      "Option 3"
-                    ],
+                    "choices": ["Option 1", "Option 2", "Option 3"],
                     "options": {
                       "selectableCount": 1
                     }
@@ -1962,9 +1876,7 @@
     },
     "/api/{session}/send-pix-key": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -1993,12 +1905,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "phone",
-                  "keyType",
-                  "name",
-                  "key"
-                ],
+                "required": ["phone", "keyType", "name", "key"],
                 "properties": {
                   "phone": {
                     "type": "string"
@@ -2039,9 +1946,7 @@
     },
     "/api/{session}/all-broadcast-list": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -2071,9 +1976,7 @@
     },
     "/api/{session}/all-groups": {
       "get": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "summary": "Deprecated in favor of ",
         "description": "",
         "parameters": [
@@ -2240,9 +2143,7 @@
     },
     "/api/{session}/group-members/{groupId}": {
       "get": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -2280,9 +2181,7 @@
     },
     "/api/{session}/common-groups/{wid}": {
       "get": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -2321,9 +2220,7 @@
     },
     "/api/{session}/group-admins/{groupId}": {
       "get": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -2368,9 +2265,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "groupId"
-                ]
+                "required": ["groupId"]
               },
               "examples": {
                 "Default": {
@@ -2386,9 +2281,7 @@
     },
     "/api/{session}/group-info/{groupId}": {
       "get": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "summary": "Get detailed information about a group",
         "description": "",
         "parameters": [
@@ -2526,9 +2419,7 @@
     },
     "/api/{session}/group-invite-link/{groupId}": {
       "get": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -2581,9 +2472,7 @@
     },
     "/api/{session}/group-revoke-link/{groupId}": {
       "get": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -2636,9 +2525,7 @@
     },
     "/api/{session}/group-members-ids/{groupId}": {
       "get": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -2677,9 +2564,7 @@
     },
     "/api/{session}/create-group": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -2722,17 +2607,12 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "participants",
-                  "name"
-                ]
+                "required": ["participants", "name"]
               },
               "examples": {
                 "Default": {
                   "value": {
-                    "participants": [
-                      "5521999999999"
-                    ],
+                    "participants": ["5521999999999"],
                     "name": "Group name"
                   }
                 }
@@ -2744,9 +2624,7 @@
     },
     "/api/{session}/leave-group": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -2783,9 +2661,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "groupId"
-                ]
+                "required": ["groupId"]
               }
             }
           }
@@ -2794,9 +2670,7 @@
     },
     "/api/{session}/join-code": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -2836,9 +2710,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "inviteCode"
-                ]
+                "required": ["inviteCode"]
               },
               "examples": {
                 "Default": {
@@ -2854,9 +2726,7 @@
     },
     "/api/{session}/add-participant-group": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -2896,10 +2766,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "groupId",
-                  "phone"
-                ]
+                "required": ["groupId", "phone"]
               },
               "examples": {
                 "Default": {
@@ -2916,9 +2783,7 @@
     },
     "/api/{session}/remove-participant-group": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -2958,10 +2823,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "groupId",
-                  "phone"
-                ]
+                "required": ["groupId", "phone"]
               },
               "examples": {
                 "Default": {
@@ -2978,9 +2840,7 @@
     },
     "/api/{session}/promote-participant-group": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -3020,10 +2880,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "groupId",
-                  "phone"
-                ]
+                "required": ["groupId", "phone"]
               },
               "examples": {
                 "Default": {
@@ -3040,9 +2897,7 @@
     },
     "/api/{session}/demote-participant-group": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -3082,10 +2937,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "groupId",
-                  "phone"
-                ]
+                "required": ["groupId", "phone"]
               },
               "examples": {
                 "Default": {
@@ -3102,9 +2954,7 @@
     },
     "/api/{session}/group-info-from-invite-link": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -3149,9 +2999,7 @@
     },
     "/api/{session}/group-description": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -3199,9 +3047,7 @@
     },
     "/api/{session}/group-property": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -3252,9 +3098,7 @@
     },
     "/api/{session}/group-subject": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -3302,9 +3146,7 @@
     },
     "/api/{session}/messages-admins-only": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -3352,9 +3194,7 @@
     },
     "/api/{session}/group-pic": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -3405,9 +3245,7 @@
     },
     "/api/{session}/change-privacy-group": {
       "post": {
-        "tags": [
-          "Group"
-        ],
+        "tags": ["Group"],
         "description": "",
         "parameters": [
           {
@@ -3455,9 +3293,7 @@
     },
     "/api/{session}/all-chats": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "summary": "Deprecated in favor of ",
         "description": "This body is not required. Not sent body to get all chats or filter.",
         "parameters": [
@@ -3522,9 +3358,7 @@
                   "example": "My new status"
                 }
               },
-              "required": [
-                "status"
-              ]
+              "required": ["status"]
             }
           },
           {
@@ -3632,9 +3466,7 @@
     },
     "/api/{session}/list-chats": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "summary": "Retrieve a list of chats",
         "description": "This body is not required. Not sent body to get all chats or filter.",
         "parameters": [
@@ -3731,9 +3563,7 @@
     },
     "/api/{session}/all-chats-archived": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "Retrieves all archived chats.",
         "parameters": [
           {
@@ -3763,9 +3593,7 @@
     },
     "/api/{session}/all-chats-with-messages": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "summary": "Deprecated in favor of list-chats",
         "description": "",
         "parameters": [
@@ -3797,9 +3625,7 @@
     },
     "/api/{session}/all-messages-in-chat/{phone}": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -3862,9 +3688,7 @@
     },
     "/api/{session}/all-new-messages": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -3894,9 +3718,7 @@
     },
     "/api/{session}/unread-messages": {
       "get": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -3927,9 +3749,7 @@
     },
     "/api/{session}/all-unread-messages": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -3959,9 +3779,7 @@
     },
     "/api/{session}/chat-by-id/{phone}": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4008,9 +3826,7 @@
     },
     "/api/{session}/message-by-id/{messageId}": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4046,9 +3862,7 @@
     },
     "/api/{session}/chat-is-online/{phone}": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4087,9 +3901,7 @@
     },
     "/api/{session}/last-seen/{phone}": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4128,9 +3940,7 @@
     },
     "/api/{session}/list-mutes/{type}": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4169,9 +3979,7 @@
     },
     "/api/{session}/load-messages-in-chat/{phone}": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4227,9 +4035,7 @@
     },
     "/api/{session}/get-messages/{phone}": {
       "get": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -4292,9 +4098,7 @@
     },
     "/api/{session}/archive-chat": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4354,9 +4158,7 @@
     },
     "/api/{session}/archive-all-chats": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4386,9 +4188,7 @@
     },
     "/api/{session}/clear-chat": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4441,9 +4241,7 @@
     },
     "/api/{session}/clear-all-chats": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4473,9 +4271,7 @@
     },
     "/api/{session}/delete-chat": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4528,9 +4324,7 @@
     },
     "/api/{session}/delete-all-chats": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4560,9 +4354,7 @@
     },
     "/api/{session}/delete-message": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -4639,9 +4431,7 @@
     },
     "/api/{session}/react-message": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -4697,9 +4487,7 @@
     },
     "/api/{session}/forward-messages": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -4759,9 +4547,7 @@
     },
     "/api/{session}/mark-unseen": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -4817,9 +4603,7 @@
     },
     "/api/{session}/pin-chat": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -4850,11 +4634,7 @@
                   "example": true
                 }
               },
-              "required": [
-                "phone",
-                "isGroup",
-                "state"
-              ]
+              "required": ["phone", "isGroup", "state"]
             }
           }
         ],
@@ -4904,9 +4684,7 @@
     },
     "/api/{session}/contact-vcard": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -4959,9 +4737,7 @@
                     "phone": "5521999999999",
                     "isGroup": false,
                     "name": "Name of contact",
-                    "contactsId": [
-                      "5521999999999"
-                    ]
+                    "contactsId": ["5521999999999"]
                   }
                 }
               }
@@ -4972,9 +4748,7 @@
     },
     "/api/{session}/send-mute": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -5038,9 +4812,7 @@
     },
     "/api/{session}/send-seen": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -5093,9 +4865,7 @@
     },
     "/api/{session}/chat-state": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -5156,9 +4926,7 @@
     },
     "/api/{session}/temporary-messages": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -5218,9 +4986,7 @@
     },
     "/api/{session}/typing": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -5280,9 +5046,7 @@
     },
     "/api/{session}/recording": {
       "post": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -5346,9 +5110,7 @@
     },
     "/api/{session}/star-message": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -5404,9 +5166,7 @@
     },
     "/api/{session}/reactions/{id}": {
       "get": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -5452,9 +5212,7 @@
     },
     "/api/{session}/votes/{id}": {
       "get": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -5500,9 +5258,7 @@
     },
     "/api/{session}/reject-call": {
       "post": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -5552,11 +5308,314 @@
         }
       }
     },
+    "/api/{session}/enable-call-interface": {
+      "post": {
+        "tags": ["Calls"],
+        "description": "Enables the WhatsApp Web call interface for the current session.",
+        "parameters": [
+          {
+            "name": "session",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/api/{session}/accept-call": {
+      "post": {
+        "tags": ["Calls"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "session",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "callId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{session}/end-call": {
+      "post": {
+        "tags": ["Calls"],
+        "description": "",
+        "parameters": [
+          {
+            "name": "session",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "callId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{session}/offer-call": {
+      "post": {
+        "tags": ["Calls"],
+        "description": "Sends a WhatsApp call signalling offer. This endpoint does not transport audio or video media.",
+        "parameters": [
+          {
+            "name": "session",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["phone"],
+                "properties": {
+                  "phone": {
+                    "type": "string"
+                  },
+                  "isVideo": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{session}/start-incoming-call-audio": {
+      "post": {
+        "tags": ["Calls"],
+        "description": "Experimental: captures incoming WebRTC call audio and emits PCM16 chunks through the authenticated /call-media Socket.IO namespace. Start before accepting the call.",
+        "parameters": [
+          {
+            "name": "session",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["callId"],
+                "properties": {
+                  "callId": {
+                    "type": "string"
+                  },
+                  "timesliceMs": {
+                    "type": "number",
+                    "minimum": 100,
+                    "default": 250
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{session}/call-media-ticket": {
+      "post": {
+        "tags": ["Calls"],
+        "description": "Creates a short-lived, single-use ticket for the authenticated call media Socket.IO namespace.",
+        "parameters": [
+          {
+            "name": "session",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "409": {
+            "description": "Conflict"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["callId"],
+                "properties": {
+                  "callId": {
+                    "type": "string"
+                  },
+                  "ttlMs": {
+                    "type": "number",
+                    "minimum": 1000,
+                    "maximum": 300000,
+                    "default": 60000
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/{session}/stop-call-media": {
+      "post": {
+        "tags": ["Calls"],
+        "description": "Stops incoming and outgoing call audio, invalidates tickets, and disconnects the active media socket for the session.",
+        "parameters": [
+          {
+            "name": "session",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
     "/api/{session}/get-products": {
       "get": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -5605,9 +5664,7 @@
     },
     "/api/{session}/get-product-by-id": {
       "get": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -5656,9 +5713,7 @@
     },
     "/api/{session}/add-product": {
       "post": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -5737,9 +5792,7 @@
     },
     "/api/{session}/edit-product": {
       "post": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -5800,9 +5853,7 @@
     },
     "/api/{session}/del-products": {
       "post": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -5857,9 +5908,7 @@
     },
     "/api/{session}/change-product-image": {
       "post": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -5918,9 +5967,7 @@
     },
     "/api/{session}/add-product-image": {
       "post": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -5979,9 +6026,7 @@
     },
     "/api/{session}/remove-product-image": {
       "post": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -6040,9 +6085,7 @@
     },
     "/api/{session}/get-collections": {
       "get": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -6099,9 +6142,7 @@
     },
     "/api/{session}/create-collection": {
       "post": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -6149,10 +6190,7 @@
                 "Default": {
                   "value": {
                     "name": "Collection name",
-                    "products": [
-                      "<id_product1>",
-                      "<id_product2>"
-                    ]
+                    "products": ["<id_product1>", "<id_product2>"]
                   }
                 }
               }
@@ -6163,9 +6201,7 @@
     },
     "/api/{session}/edit-collection": {
       "post": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -6226,9 +6262,7 @@
     },
     "/api/{session}/del-collection": {
       "post": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -6283,9 +6317,7 @@
     },
     "/api/{session}/send-link-catalog": {
       "post": {
-        "tags": [
-          "Messages"
-        ],
+        "tags": ["Messages"],
         "description": "",
         "parameters": [
           {
@@ -6332,9 +6364,7 @@
               "examples": {
                 "Default": {
                   "value": {
-                    "phones": [
-                      "<array_phone_id"
-                    ],
+                    "phones": ["<array_phone_id"],
                     "message": "Message"
                   }
                 }
@@ -6346,9 +6376,7 @@
     },
     "/api/{session}/set-product-visibility": {
       "post": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -6375,10 +6403,7 @@
                   "example": false
                 }
               },
-              "required": [
-                "id",
-                "value"
-              ]
+              "required": ["id", "value"]
             }
           }
         ],
@@ -6428,9 +6453,7 @@
     },
     "/api/{session}/set-cart-enabled": {
       "post": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -6485,9 +6508,7 @@
     },
     "/api/{session}/send-text-storie": {
       "post": {
-        "tags": [
-          "Status Stories"
-        ],
+        "tags": ["Status Stories"],
         "description": "",
         "parameters": [
           {
@@ -6553,9 +6574,7 @@
                     "type": "object"
                   }
                 },
-                "required": [
-                  "text"
-                ]
+                "required": ["text"]
               },
               "examples": {
                 "Default": {
@@ -6575,9 +6594,7 @@
     },
     "/api/{session}/send-image-storie": {
       "post": {
-        "tags": [
-          "Status Stories"
-        ],
+        "tags": ["Status Stories"],
         "description": "",
         "parameters": [
           {
@@ -6614,9 +6631,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "path"
-                ]
+                "required": ["path"]
               },
               "examples": {
                 "Default": {
@@ -6632,9 +6647,7 @@
     },
     "/api/{session}/send-video-storie": {
       "post": {
-        "tags": [
-          "Status Stories"
-        ],
+        "tags": ["Status Stories"],
         "description": "",
         "parameters": [
           {
@@ -6671,9 +6684,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "path"
-                ]
+                "required": ["path"]
               },
               "examples": {
                 "Default": {
@@ -6689,9 +6700,7 @@
     },
     "/api/{session}/add-new-label": {
       "post": {
-        "tags": [
-          "Labels"
-        ],
+        "tags": ["Labels"],
         "description": "",
         "parameters": [
           {
@@ -6739,10 +6748,7 @@
                     }
                   }
                 },
-                "required": [
-                  "name",
-                  "options"
-                ]
+                "required": ["name", "options"]
               },
               "examples": {
                 "Default": {
@@ -6761,9 +6767,7 @@
     },
     "/api/{session}/add-or-remove-label": {
       "post": {
-        "tags": [
-          "Labels"
-        ],
+        "tags": ["Labels"],
         "description": "",
         "parameters": [
           {
@@ -6820,16 +6824,12 @@
                     }
                   }
                 },
-                "required": [
-                  "chatIds"
-                ]
+                "required": ["chatIds"]
               },
               "examples": {
                 "Default": {
                   "value": {
-                    "chatIds": [
-                      "5521999999999"
-                    ],
+                    "chatIds": ["5521999999999"],
                     "options": [
                       {
                         "labelId": "76",
@@ -6850,9 +6850,7 @@
     },
     "/api/{session}/get-all-labels": {
       "get": {
-        "tags": [
-          "Labels"
-        ],
+        "tags": ["Labels"],
         "description": "",
         "parameters": [
           {
@@ -6882,9 +6880,7 @@
     },
     "/api/{session}/delete-all-labels": {
       "put": {
-        "tags": [
-          "Labels"
-        ],
+        "tags": ["Labels"],
         "description": "",
         "parameters": [
           {
@@ -6914,9 +6910,7 @@
     },
     "/api/{session}/delete-label/{id}": {
       "put": {
-        "tags": [
-          "Labels"
-        ],
+        "tags": ["Labels"],
         "description": "",
         "parameters": [
           {
@@ -6955,9 +6949,7 @@
     },
     "/api/{session}/check-number-status/{phone}": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -7016,9 +7008,7 @@
     },
     "/api/{session}/contact/{phone}": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -7057,9 +7047,7 @@
     },
     "/api/{session}/contact/pn-lid/{pnLid}": {
       "get": {
-        "tags": [
-          "Contact"
-        ],
+        "tags": ["Contact"],
         "description": "",
         "parameters": [
           {
@@ -7100,9 +7088,7 @@
     },
     "/api/{session}/profile/{phone}": {
       "get": {
-        "tags": [
-          "Chat"
-        ],
+        "tags": ["Chat"],
         "description": "",
         "parameters": [
           {
@@ -7142,9 +7128,7 @@
     },
     "/api/{session}/profile-pic/{phone}": {
       "get": {
-        "tags": [
-          "Contact"
-        ],
+        "tags": ["Contact"],
         "description": "",
         "parameters": [
           {
@@ -7190,9 +7174,7 @@
     },
     "/api/{session}/profile-status/{phone}": {
       "get": {
-        "tags": [
-          "Contact"
-        ],
+        "tags": ["Contact"],
         "description": "",
         "parameters": [
           {
@@ -7231,9 +7213,7 @@
     },
     "/api/{session}/blocklist": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -7263,9 +7243,7 @@
     },
     "/api/{session}/block-contact": {
       "post": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -7321,9 +7299,7 @@
     },
     "/api/{session}/unblock-contact": {
       "post": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -7379,9 +7355,7 @@
     },
     "/api/{session}/get-battery-level": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -7411,9 +7385,7 @@
     },
     "/api/{session}/host-device": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -7443,9 +7415,7 @@
     },
     "/api/{session}/get-phone-number": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -7475,9 +7445,7 @@
     },
     "/api/{session}/set-profile-pic": {
       "post": {
-        "tags": [
-          "Profile"
-        ],
+        "tags": ["Profile"],
         "description": "",
         "parameters": [
           {
@@ -7518,9 +7486,7 @@
     },
     "/api/{session}/profile-status": {
       "post": {
-        "tags": [
-          "Profile"
-        ],
+        "tags": ["Profile"],
         "description": "",
         "parameters": [
           {
@@ -7543,9 +7509,7 @@
                   "example": "My new status"
                 }
               },
-              "required": [
-                "status"
-              ]
+              "required": ["status"]
             }
           }
         ],
@@ -7588,9 +7552,7 @@
     },
     "/api/{session}/change-username": {
       "post": {
-        "tags": [
-          "Profile"
-        ],
+        "tags": ["Profile"],
         "description": "",
         "parameters": [
           {
@@ -7645,9 +7607,7 @@
     },
     "/api/{session}/edit-business-profile": {
       "post": {
-        "tags": [
-          "Profile"
-        ],
+        "tags": ["Profile"],
         "description": "Edit your bussiness profile",
         "operationId": "editBusinessProfile",
         "parameters": [
@@ -7690,11 +7650,7 @@
                       "example": false
                     }
                   },
-                  "required": [
-                    "id",
-                    "localized_display_name",
-                    "not_a_biz"
-                  ]
+                  "required": ["id", "localized_display_name", "not_a_biz"]
                 },
                 "website": {
                   "type": "array",
@@ -7707,12 +7663,7 @@
                   }
                 }
               },
-              "required": [
-                "adress",
-                "email",
-                "categories",
-                "website"
-              ]
+              "required": ["adress", "email", "categories", "website"]
             }
           }
         ],
@@ -7770,9 +7721,7 @@
     },
     "/api/{session}/get-business-profiles-products": {
       "get": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -7807,9 +7756,7 @@
     },
     "/api/{session}/get-order-by-messageId/{messageId}": {
       "get": {
-        "tags": [
-          "Catalog & Bussiness"
-        ],
+        "tags": ["Catalog & Bussiness"],
         "description": "",
         "parameters": [
           {
@@ -7845,13 +7792,9 @@
     },
     "/api/{secretkey}/backup-sessions": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "Please, open the router in your browser, in swagger this not run",
-        "produces": [
-          "application/zip"
-        ],
+        "produces": ["application/zip"],
         "parameters": [
           {
             "name": "secretkey",
@@ -7883,9 +7826,7 @@
     },
     "/api/{secretkey}/restore-sessions": {
       "post": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -7921,9 +7862,7 @@
                     "format": "binary"
                   }
                 },
-                "required": [
-                  "file"
-                ]
+                "required": ["file"]
               }
             }
           }
@@ -7932,9 +7871,7 @@
     },
     "/api/{session}/take-screenshot": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "",
         "parameters": [
           {
@@ -7964,9 +7901,7 @@
     },
     "/api/{session}/set-limit": {
       "post": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "Change limits of whatsapp web. Types value: maxMediaSize, maxFileSize, maxShare, statusVideoMaxDuration, unlimitedPin;",
         "parameters": [
           {
@@ -8006,10 +7941,7 @@
                     "type": "any"
                   }
                 },
-                "required": [
-                  "type",
-                  "value"
-                ]
+                "required": ["type", "value"]
               },
               "examples": {
                 "Default": {
@@ -8026,9 +7958,7 @@
     },
     "/api/{session}/create-community": {
       "post": {
-        "tags": [
-          "Community"
-        ],
+        "tags": ["Community"],
         "description": "",
         "parameters": [
           {
@@ -8077,10 +8007,7 @@
                   "value": {
                     "name": "My community name",
                     "description": "Description for your community",
-                    "groupIds": [
-                      "groupId1",
-                      "groupId2"
-                    ]
+                    "groupIds": ["groupId1", "groupId2"]
                   }
                 }
               }
@@ -8091,9 +8018,7 @@
     },
     "/api/{session}/deactivate-community": {
       "post": {
-        "tags": [
-          "Community"
-        ],
+        "tags": ["Community"],
         "description": "",
         "parameters": [
           {
@@ -8145,9 +8070,7 @@
     },
     "/api/{session}/add-community-subgroup": {
       "post": {
-        "tags": [
-          "Community"
-        ],
+        "tags": ["Community"],
         "description": "",
         "parameters": [
           {
@@ -8192,9 +8115,7 @@
                 "Default": {
                   "value": {
                     "id": "<you_community_id@g.us>",
-                    "groupsIds": [
-                      "group1Id@g.us"
-                    ]
+                    "groupsIds": ["group1Id@g.us"]
                   }
                 }
               }
@@ -8205,9 +8126,7 @@
     },
     "/api/{session}/remove-community-subgroup": {
       "post": {
-        "tags": [
-          "Community"
-        ],
+        "tags": ["Community"],
         "description": "",
         "parameters": [
           {
@@ -8252,9 +8171,7 @@
                 "Default": {
                   "value": {
                     "id": "<you_community_id@g.us>",
-                    "groupsIds": [
-                      "group1Id@g.us"
-                    ]
+                    "groupsIds": ["group1Id@g.us"]
                   }
                 }
               }
@@ -8265,9 +8182,7 @@
     },
     "/api/{session}/promote-community-participant": {
       "post": {
-        "tags": [
-          "Community"
-        ],
+        "tags": ["Community"],
         "description": "",
         "parameters": [
           {
@@ -8312,9 +8227,7 @@
                 "Default": {
                   "value": {
                     "id": "<you_community_id@g.us>",
-                    "participantsId": [
-                      "group1Id@g.us"
-                    ]
+                    "participantsId": ["group1Id@g.us"]
                   }
                 }
               }
@@ -8325,9 +8238,7 @@
     },
     "/api/{session}/demote-community-participant": {
       "post": {
-        "tags": [
-          "Community"
-        ],
+        "tags": ["Community"],
         "description": "",
         "parameters": [
           {
@@ -8372,9 +8283,7 @@
                 "Default": {
                   "value": {
                     "id": "<you_community_id@g.us>",
-                    "participantsId": [
-                      "group1Id@g.us"
-                    ]
+                    "participantsId": ["group1Id@g.us"]
                   }
                 }
               }
@@ -8385,9 +8294,7 @@
     },
     "/api/{session}/community-participants/{id}": {
       "get": {
-        "tags": [
-          "Community"
-        ],
+        "tags": ["Community"],
         "description": "",
         "parameters": [
           {
@@ -8649,9 +8556,7 @@
     },
     "/api/{session}/chatwoot": {
       "post": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "You can point your Chatwoot to this route so that it can perform functions.",
         "parameters": [
           {
@@ -8717,9 +8622,7 @@
     },
     "/healthz": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "This endpoint can be used to check the health status of the API. It returns a response with a status code indicating the API",
         "responses": {
           "default": {
@@ -8730,9 +8633,7 @@
     },
     "/unhealthy": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "This endpoint is used to force the API into an unhealthy state. It can be useful for testing error handling or simulating service disruptions.",
         "responses": {
           "default": {
@@ -8743,9 +8644,7 @@
     },
     "/metrics": {
       "get": {
-        "tags": [
-          "Misc"
-        ],
+        "tags": ["Misc"],
         "description": "This endpoint can be used to check the status of API metrics. It returns a response with the collected metrics.",
         "responses": {
           "default": {

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -54,7 +54,9 @@
   "paths": {
     "/api/{session}/{secretkey}/generate-token": {
       "post": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "description": "",
         "parameters": [
           {
@@ -91,7 +93,9 @@
     },
     "/api/{secretkey}/show-all-sessions": {
       "get": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "description": "",
         "operationId": "showAllSessions",
         "parameters": [
@@ -122,7 +126,9 @@
     },
     "/api/{secretkey}/start-all": {
       "post": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "description": "",
         "operationId": "startAllSessions",
         "parameters": [
@@ -168,7 +174,9 @@
     },
     "/api/{session}/check-connection-session": {
       "get": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "description": "",
         "operationId": "CheckConnectionState",
         "parameters": [
@@ -196,7 +204,9 @@
     },
     "/api/{session}/get-media-by-message/{messageId}": {
       "get": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "operationId": "getMediaByMessage",
         "parameters": [
@@ -238,7 +248,9 @@
     },
     "/api/{session}/get-platform-from-message/{messageId}": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -277,7 +289,9 @@
     },
     "/api/{session}/qrcode-session": {
       "get": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "description": "",
         "operationId": "getQrCode",
         "parameters": [
@@ -308,7 +322,9 @@
     },
     "/api/{session}/start-session": {
       "post": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "description": "",
         "operationId": "startSession",
         "parameters": [
@@ -377,7 +393,9 @@
     },
     "/api/{session}/logout-session": {
       "post": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "description": "This route logout and delete session data",
         "operationId": "logoutSession",
         "parameters": [
@@ -408,7 +426,9 @@
     },
     "/api/{session}/{secretkey}/clear-session-data": {
       "post": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -445,7 +465,9 @@
     },
     "/api/{session}/close-session": {
       "post": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "description": "",
         "operationId": "closeSession",
         "parameters": [
@@ -476,7 +498,9 @@
     },
     "/api/{session}/subscribe-presence": {
       "post": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "operationId": "subscribePresence",
         "parameters": [
@@ -533,7 +557,9 @@
     },
     "/api/{session}/set-online-presence": {
       "post": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "operationId": "setOnlinePresence",
         "parameters": [
@@ -582,7 +608,9 @@
     },
     "/api/{session}/download-media": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "operationId": "downloadMediabyMessage",
         "parameters": [
@@ -631,7 +659,9 @@
     },
     "/api/{session}/send-message": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -718,7 +748,9 @@
     },
     "/api/{session}/edit-message": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -774,7 +806,9 @@
     },
     "/api/{session}/send-image": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -850,7 +884,9 @@
     },
     "/api/{session}/send-sticker": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -893,7 +929,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["phone", "path"]
+                "required": [
+                  "phone",
+                  "path"
+                ]
               },
               "examples": {
                 "Default": {
@@ -911,7 +950,9 @@
     },
     "/api/{session}/send-sticker-gif": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -954,7 +995,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["phone", "path"]
+                "required": [
+                  "phone",
+                  "path"
+                ]
               },
               "examples": {
                 "Default": {
@@ -972,7 +1016,9 @@
     },
     "/api/{session}/send-reply": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1033,7 +1079,9 @@
     },
     "/api/{session}/send-file": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1109,7 +1157,9 @@
     },
     "/api/{session}/send-file-base64": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1185,7 +1235,9 @@
     },
     "/api/{session}/send-voice": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1246,7 +1298,9 @@
     },
     "/api/{session}/send-voice-base64": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1303,7 +1357,9 @@
     },
     "/api/{session}/status-session": {
       "get": {
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "description": "",
         "operationId": "closeSession",
         "parameters": [
@@ -1334,7 +1390,9 @@
     },
     "/api/{session}/send-status": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1377,7 +1435,11 @@
                     "type": "string"
                   }
                 },
-                "required": ["phone", "isGroup", "message"]
+                "required": [
+                  "phone",
+                  "isGroup",
+                  "message"
+                ]
               },
               "examples": {
                 "Default": {
@@ -1396,7 +1458,9 @@
     },
     "/api/{session}/send-link-preview": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1457,7 +1521,9 @@
     },
     "/api/{session}/send-location": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1526,7 +1592,9 @@
     },
     "/api/{session}/send-mentioned": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1575,7 +1643,11 @@
                     }
                   }
                 },
-                "required": ["phone", "message", "mentioned"]
+                "required": [
+                  "phone",
+                  "message",
+                  "mentioned"
+                ]
               },
               "examples": {
                 "Default": {
@@ -1583,7 +1655,9 @@
                     "phone": "groupId@g.us",
                     "isGroup": true,
                     "message": "Your text message",
-                    "mentioned": ["556593077171@c.us"]
+                    "mentioned": [
+                      "556593077171@c.us"
+                    ]
                   }
                 }
               }
@@ -1594,7 +1668,9 @@
     },
     "/api/{session}/send-buttons": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1622,7 +1698,9 @@
     },
     "/api/{session}/send-list-message": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1703,7 +1781,9 @@
     },
     "/api/{session}/send-order-message": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1809,7 +1889,9 @@
     },
     "/api/{session}/send-poll-message": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1862,7 +1944,11 @@
                     "phone": "5521999999999",
                     "isGroup": false,
                     "name": "Poll name",
-                    "choices": ["Option 1", "Option 2", "Option 3"],
+                    "choices": [
+                      "Option 1",
+                      "Option 2",
+                      "Option 3"
+                    ],
                     "options": {
                       "selectableCount": 1
                     }
@@ -1876,7 +1962,9 @@
     },
     "/api/{session}/send-pix-key": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1905,7 +1993,12 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["phone", "keyType", "name", "key"],
+                "required": [
+                  "phone",
+                  "keyType",
+                  "name",
+                  "key"
+                ],
                 "properties": {
                   "phone": {
                     "type": "string"
@@ -1946,7 +2039,9 @@
     },
     "/api/{session}/all-broadcast-list": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -1976,7 +2071,9 @@
     },
     "/api/{session}/all-groups": {
       "get": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "summary": "Deprecated in favor of ",
         "description": "",
         "parameters": [
@@ -2143,7 +2240,9 @@
     },
     "/api/{session}/group-members/{groupId}": {
       "get": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2181,7 +2280,9 @@
     },
     "/api/{session}/common-groups/{wid}": {
       "get": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2220,7 +2321,9 @@
     },
     "/api/{session}/group-admins/{groupId}": {
       "get": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2265,7 +2368,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["groupId"]
+                "required": [
+                  "groupId"
+                ]
               },
               "examples": {
                 "Default": {
@@ -2281,7 +2386,9 @@
     },
     "/api/{session}/group-info/{groupId}": {
       "get": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "summary": "Get detailed information about a group",
         "description": "",
         "parameters": [
@@ -2419,7 +2526,9 @@
     },
     "/api/{session}/group-invite-link/{groupId}": {
       "get": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2472,7 +2581,9 @@
     },
     "/api/{session}/group-revoke-link/{groupId}": {
       "get": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2525,7 +2636,9 @@
     },
     "/api/{session}/group-members-ids/{groupId}": {
       "get": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2564,7 +2677,9 @@
     },
     "/api/{session}/create-group": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2607,12 +2722,17 @@
                     "type": "string"
                   }
                 },
-                "required": ["participants", "name"]
+                "required": [
+                  "participants",
+                  "name"
+                ]
               },
               "examples": {
                 "Default": {
                   "value": {
-                    "participants": ["5521999999999"],
+                    "participants": [
+                      "5521999999999"
+                    ],
                     "name": "Group name"
                   }
                 }
@@ -2624,7 +2744,9 @@
     },
     "/api/{session}/leave-group": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2661,7 +2783,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["groupId"]
+                "required": [
+                  "groupId"
+                ]
               }
             }
           }
@@ -2670,7 +2794,9 @@
     },
     "/api/{session}/join-code": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2710,7 +2836,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["inviteCode"]
+                "required": [
+                  "inviteCode"
+                ]
               },
               "examples": {
                 "Default": {
@@ -2726,7 +2854,9 @@
     },
     "/api/{session}/add-participant-group": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2766,7 +2896,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["groupId", "phone"]
+                "required": [
+                  "groupId",
+                  "phone"
+                ]
               },
               "examples": {
                 "Default": {
@@ -2783,7 +2916,9 @@
     },
     "/api/{session}/remove-participant-group": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2823,7 +2958,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["groupId", "phone"]
+                "required": [
+                  "groupId",
+                  "phone"
+                ]
               },
               "examples": {
                 "Default": {
@@ -2840,7 +2978,9 @@
     },
     "/api/{session}/promote-participant-group": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2880,7 +3020,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["groupId", "phone"]
+                "required": [
+                  "groupId",
+                  "phone"
+                ]
               },
               "examples": {
                 "Default": {
@@ -2897,7 +3040,9 @@
     },
     "/api/{session}/demote-participant-group": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2937,7 +3082,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["groupId", "phone"]
+                "required": [
+                  "groupId",
+                  "phone"
+                ]
               },
               "examples": {
                 "Default": {
@@ -2954,7 +3102,9 @@
     },
     "/api/{session}/group-info-from-invite-link": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -2999,7 +3149,9 @@
     },
     "/api/{session}/group-description": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3047,7 +3199,9 @@
     },
     "/api/{session}/group-property": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3098,7 +3252,9 @@
     },
     "/api/{session}/group-subject": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3146,7 +3302,9 @@
     },
     "/api/{session}/messages-admins-only": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3194,7 +3352,9 @@
     },
     "/api/{session}/group-pic": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3245,7 +3405,9 @@
     },
     "/api/{session}/change-privacy-group": {
       "post": {
-        "tags": ["Group"],
+        "tags": [
+          "Group"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3293,7 +3455,9 @@
     },
     "/api/{session}/all-chats": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "summary": "Deprecated in favor of ",
         "description": "This body is not required. Not sent body to get all chats or filter.",
         "parameters": [
@@ -3358,7 +3522,9 @@
                   "example": "My new status"
                 }
               },
-              "required": ["status"]
+              "required": [
+                "status"
+              ]
             }
           },
           {
@@ -3466,7 +3632,9 @@
     },
     "/api/{session}/list-chats": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "summary": "Retrieve a list of chats",
         "description": "This body is not required. Not sent body to get all chats or filter.",
         "parameters": [
@@ -3563,7 +3731,9 @@
     },
     "/api/{session}/all-chats-archived": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "Retrieves all archived chats.",
         "parameters": [
           {
@@ -3593,7 +3763,9 @@
     },
     "/api/{session}/all-chats-with-messages": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "summary": "Deprecated in favor of list-chats",
         "description": "",
         "parameters": [
@@ -3625,7 +3797,9 @@
     },
     "/api/{session}/all-messages-in-chat/{phone}": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3688,7 +3862,9 @@
     },
     "/api/{session}/all-new-messages": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3718,7 +3894,9 @@
     },
     "/api/{session}/unread-messages": {
       "get": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3749,7 +3927,9 @@
     },
     "/api/{session}/all-unread-messages": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3779,7 +3959,9 @@
     },
     "/api/{session}/chat-by-id/{phone}": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3826,7 +4008,9 @@
     },
     "/api/{session}/message-by-id/{messageId}": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3862,7 +4046,9 @@
     },
     "/api/{session}/chat-is-online/{phone}": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3901,7 +4087,9 @@
     },
     "/api/{session}/last-seen/{phone}": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3940,7 +4128,9 @@
     },
     "/api/{session}/list-mutes/{type}": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -3979,7 +4169,9 @@
     },
     "/api/{session}/load-messages-in-chat/{phone}": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4035,7 +4227,9 @@
     },
     "/api/{session}/get-messages/{phone}": {
       "get": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4098,7 +4292,9 @@
     },
     "/api/{session}/archive-chat": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4158,7 +4354,9 @@
     },
     "/api/{session}/archive-all-chats": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4188,7 +4386,9 @@
     },
     "/api/{session}/clear-chat": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4241,7 +4441,9 @@
     },
     "/api/{session}/clear-all-chats": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4271,7 +4473,9 @@
     },
     "/api/{session}/delete-chat": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4324,7 +4528,9 @@
     },
     "/api/{session}/delete-all-chats": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4354,7 +4560,9 @@
     },
     "/api/{session}/delete-message": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4431,7 +4639,9 @@
     },
     "/api/{session}/react-message": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4487,7 +4697,9 @@
     },
     "/api/{session}/forward-messages": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4547,7 +4759,9 @@
     },
     "/api/{session}/mark-unseen": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4603,7 +4817,9 @@
     },
     "/api/{session}/pin-chat": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4634,7 +4850,11 @@
                   "example": true
                 }
               },
-              "required": ["phone", "isGroup", "state"]
+              "required": [
+                "phone",
+                "isGroup",
+                "state"
+              ]
             }
           }
         ],
@@ -4684,7 +4904,9 @@
     },
     "/api/{session}/contact-vcard": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4737,7 +4959,9 @@
                     "phone": "5521999999999",
                     "isGroup": false,
                     "name": "Name of contact",
-                    "contactsId": ["5521999999999"]
+                    "contactsId": [
+                      "5521999999999"
+                    ]
                   }
                 }
               }
@@ -4748,7 +4972,9 @@
     },
     "/api/{session}/send-mute": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4812,7 +5038,9 @@
     },
     "/api/{session}/send-seen": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4865,7 +5093,9 @@
     },
     "/api/{session}/chat-state": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4926,7 +5156,9 @@
     },
     "/api/{session}/temporary-messages": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -4986,7 +5218,9 @@
     },
     "/api/{session}/typing": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5046,7 +5280,9 @@
     },
     "/api/{session}/recording": {
       "post": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5110,7 +5346,9 @@
     },
     "/api/{session}/star-message": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5166,7 +5404,9 @@
     },
     "/api/{session}/reactions/{id}": {
       "get": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5212,7 +5452,9 @@
     },
     "/api/{session}/votes/{id}": {
       "get": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5258,7 +5500,9 @@
     },
     "/api/{session}/reject-call": {
       "post": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5308,314 +5552,11 @@
         }
       }
     },
-    "/api/{session}/enable-call-interface": {
-      "post": {
-        "tags": ["Calls"],
-        "description": "Enables the WhatsApp Web call interface for the current session.",
-        "parameters": [
-          {
-            "name": "session",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/api/{session}/accept-call": {
-      "post": {
-        "tags": ["Calls"],
-        "description": "",
-        "parameters": [
-          {
-            "name": "session",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "callId": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/{session}/end-call": {
-      "post": {
-        "tags": ["Calls"],
-        "description": "",
-        "parameters": [
-          {
-            "name": "session",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "callId": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/{session}/offer-call": {
-      "post": {
-        "tags": ["Calls"],
-        "description": "Sends a WhatsApp call signalling offer. This endpoint does not transport audio or video media.",
-        "parameters": [
-          {
-            "name": "session",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": ["phone"],
-                "properties": {
-                  "phone": {
-                    "type": "string"
-                  },
-                  "isVideo": {
-                    "type": "boolean",
-                    "default": false
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/{session}/start-incoming-call-audio": {
-      "post": {
-        "tags": ["Calls"],
-        "description": "Experimental: captures incoming WebRTC call audio and emits PCM16 chunks through the authenticated /call-media Socket.IO namespace. Start before accepting the call.",
-        "parameters": [
-          {
-            "name": "session",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": ["callId"],
-                "properties": {
-                  "callId": {
-                    "type": "string"
-                  },
-                  "timesliceMs": {
-                    "type": "number",
-                    "minimum": 100,
-                    "default": 250
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/{session}/call-media-ticket": {
-      "post": {
-        "tags": ["Calls"],
-        "description": "Creates a short-lived, single-use ticket for the authenticated call media Socket.IO namespace.",
-        "parameters": [
-          {
-            "name": "session",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "409": {
-            "description": "Conflict"
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": ["callId"],
-                "properties": {
-                  "callId": {
-                    "type": "string"
-                  },
-                  "ttlMs": {
-                    "type": "number",
-                    "minimum": 1000,
-                    "maximum": 300000,
-                    "default": 60000
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/{session}/stop-call-media": {
-      "post": {
-        "tags": ["Calls"],
-        "description": "Stops incoming and outgoing call audio, invalidates tickets, and disconnects the active media socket for the session.",
-        "parameters": [
-          {
-            "name": "session",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
     "/api/{session}/get-products": {
       "get": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5664,7 +5605,9 @@
     },
     "/api/{session}/get-product-by-id": {
       "get": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5713,7 +5656,9 @@
     },
     "/api/{session}/add-product": {
       "post": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5792,7 +5737,9 @@
     },
     "/api/{session}/edit-product": {
       "post": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5853,7 +5800,9 @@
     },
     "/api/{session}/del-products": {
       "post": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5908,7 +5857,9 @@
     },
     "/api/{session}/change-product-image": {
       "post": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -5967,7 +5918,9 @@
     },
     "/api/{session}/add-product-image": {
       "post": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6026,7 +5979,9 @@
     },
     "/api/{session}/remove-product-image": {
       "post": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6085,7 +6040,9 @@
     },
     "/api/{session}/get-collections": {
       "get": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6142,7 +6099,9 @@
     },
     "/api/{session}/create-collection": {
       "post": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6190,7 +6149,10 @@
                 "Default": {
                   "value": {
                     "name": "Collection name",
-                    "products": ["<id_product1>", "<id_product2>"]
+                    "products": [
+                      "<id_product1>",
+                      "<id_product2>"
+                    ]
                   }
                 }
               }
@@ -6201,7 +6163,9 @@
     },
     "/api/{session}/edit-collection": {
       "post": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6262,7 +6226,9 @@
     },
     "/api/{session}/del-collection": {
       "post": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6317,7 +6283,9 @@
     },
     "/api/{session}/send-link-catalog": {
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6364,7 +6332,9 @@
               "examples": {
                 "Default": {
                   "value": {
-                    "phones": ["<array_phone_id"],
+                    "phones": [
+                      "<array_phone_id"
+                    ],
                     "message": "Message"
                   }
                 }
@@ -6376,7 +6346,9 @@
     },
     "/api/{session}/set-product-visibility": {
       "post": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6403,7 +6375,10 @@
                   "example": false
                 }
               },
-              "required": ["id", "value"]
+              "required": [
+                "id",
+                "value"
+              ]
             }
           }
         ],
@@ -6453,7 +6428,9 @@
     },
     "/api/{session}/set-cart-enabled": {
       "post": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6508,7 +6485,9 @@
     },
     "/api/{session}/send-text-storie": {
       "post": {
-        "tags": ["Status Stories"],
+        "tags": [
+          "Status Stories"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6574,7 +6553,9 @@
                     "type": "object"
                   }
                 },
-                "required": ["text"]
+                "required": [
+                  "text"
+                ]
               },
               "examples": {
                 "Default": {
@@ -6594,7 +6575,9 @@
     },
     "/api/{session}/send-image-storie": {
       "post": {
-        "tags": ["Status Stories"],
+        "tags": [
+          "Status Stories"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6631,7 +6614,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["path"]
+                "required": [
+                  "path"
+                ]
               },
               "examples": {
                 "Default": {
@@ -6647,7 +6632,9 @@
     },
     "/api/{session}/send-video-storie": {
       "post": {
-        "tags": ["Status Stories"],
+        "tags": [
+          "Status Stories"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6684,7 +6671,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["path"]
+                "required": [
+                  "path"
+                ]
               },
               "examples": {
                 "Default": {
@@ -6700,7 +6689,9 @@
     },
     "/api/{session}/add-new-label": {
       "post": {
-        "tags": ["Labels"],
+        "tags": [
+          "Labels"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6748,7 +6739,10 @@
                     }
                   }
                 },
-                "required": ["name", "options"]
+                "required": [
+                  "name",
+                  "options"
+                ]
               },
               "examples": {
                 "Default": {
@@ -6767,7 +6761,9 @@
     },
     "/api/{session}/add-or-remove-label": {
       "post": {
-        "tags": ["Labels"],
+        "tags": [
+          "Labels"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6824,12 +6820,16 @@
                     }
                   }
                 },
-                "required": ["chatIds"]
+                "required": [
+                  "chatIds"
+                ]
               },
               "examples": {
                 "Default": {
                   "value": {
-                    "chatIds": ["5521999999999"],
+                    "chatIds": [
+                      "5521999999999"
+                    ],
                     "options": [
                       {
                         "labelId": "76",
@@ -6850,7 +6850,9 @@
     },
     "/api/{session}/get-all-labels": {
       "get": {
-        "tags": ["Labels"],
+        "tags": [
+          "Labels"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6880,7 +6882,9 @@
     },
     "/api/{session}/delete-all-labels": {
       "put": {
-        "tags": ["Labels"],
+        "tags": [
+          "Labels"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6910,7 +6914,9 @@
     },
     "/api/{session}/delete-label/{id}": {
       "put": {
-        "tags": ["Labels"],
+        "tags": [
+          "Labels"
+        ],
         "description": "",
         "parameters": [
           {
@@ -6949,7 +6955,9 @@
     },
     "/api/{session}/check-number-status/{phone}": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7008,7 +7016,9 @@
     },
     "/api/{session}/contact/{phone}": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7047,7 +7057,9 @@
     },
     "/api/{session}/contact/pn-lid/{pnLid}": {
       "get": {
-        "tags": ["Contact"],
+        "tags": [
+          "Contact"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7088,7 +7100,9 @@
     },
     "/api/{session}/profile/{phone}": {
       "get": {
-        "tags": ["Chat"],
+        "tags": [
+          "Chat"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7128,7 +7142,9 @@
     },
     "/api/{session}/profile-pic/{phone}": {
       "get": {
-        "tags": ["Contact"],
+        "tags": [
+          "Contact"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7174,7 +7190,9 @@
     },
     "/api/{session}/profile-status/{phone}": {
       "get": {
-        "tags": ["Contact"],
+        "tags": [
+          "Contact"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7213,7 +7231,9 @@
     },
     "/api/{session}/blocklist": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7243,7 +7263,9 @@
     },
     "/api/{session}/block-contact": {
       "post": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7299,7 +7321,9 @@
     },
     "/api/{session}/unblock-contact": {
       "post": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7355,7 +7379,9 @@
     },
     "/api/{session}/get-battery-level": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7385,7 +7411,9 @@
     },
     "/api/{session}/host-device": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7415,7 +7443,9 @@
     },
     "/api/{session}/get-phone-number": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7445,7 +7475,9 @@
     },
     "/api/{session}/set-profile-pic": {
       "post": {
-        "tags": ["Profile"],
+        "tags": [
+          "Profile"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7486,7 +7518,9 @@
     },
     "/api/{session}/profile-status": {
       "post": {
-        "tags": ["Profile"],
+        "tags": [
+          "Profile"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7509,7 +7543,9 @@
                   "example": "My new status"
                 }
               },
-              "required": ["status"]
+              "required": [
+                "status"
+              ]
             }
           }
         ],
@@ -7552,7 +7588,9 @@
     },
     "/api/{session}/change-username": {
       "post": {
-        "tags": ["Profile"],
+        "tags": [
+          "Profile"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7607,7 +7645,9 @@
     },
     "/api/{session}/edit-business-profile": {
       "post": {
-        "tags": ["Profile"],
+        "tags": [
+          "Profile"
+        ],
         "description": "Edit your bussiness profile",
         "operationId": "editBusinessProfile",
         "parameters": [
@@ -7650,7 +7690,11 @@
                       "example": false
                     }
                   },
-                  "required": ["id", "localized_display_name", "not_a_biz"]
+                  "required": [
+                    "id",
+                    "localized_display_name",
+                    "not_a_biz"
+                  ]
                 },
                 "website": {
                   "type": "array",
@@ -7663,7 +7707,12 @@
                   }
                 }
               },
-              "required": ["adress", "email", "categories", "website"]
+              "required": [
+                "adress",
+                "email",
+                "categories",
+                "website"
+              ]
             }
           }
         ],
@@ -7721,7 +7770,9 @@
     },
     "/api/{session}/get-business-profiles-products": {
       "get": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7756,7 +7807,9 @@
     },
     "/api/{session}/get-order-by-messageId/{messageId}": {
       "get": {
-        "tags": ["Catalog & Bussiness"],
+        "tags": [
+          "Catalog & Bussiness"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7792,9 +7845,13 @@
     },
     "/api/{secretkey}/backup-sessions": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "Please, open the router in your browser, in swagger this not run",
-        "produces": ["application/zip"],
+        "produces": [
+          "application/zip"
+        ],
         "parameters": [
           {
             "name": "secretkey",
@@ -7826,7 +7883,9 @@
     },
     "/api/{secretkey}/restore-sessions": {
       "post": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7862,7 +7921,9 @@
                     "format": "binary"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               }
             }
           }
@@ -7871,7 +7932,9 @@
     },
     "/api/{session}/take-screenshot": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "",
         "parameters": [
           {
@@ -7901,7 +7964,9 @@
     },
     "/api/{session}/set-limit": {
       "post": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "Change limits of whatsapp web. Types value: maxMediaSize, maxFileSize, maxShare, statusVideoMaxDuration, unlimitedPin;",
         "parameters": [
           {
@@ -7941,7 +8006,10 @@
                     "type": "any"
                   }
                 },
-                "required": ["type", "value"]
+                "required": [
+                  "type",
+                  "value"
+                ]
               },
               "examples": {
                 "Default": {
@@ -7958,7 +8026,9 @@
     },
     "/api/{session}/create-community": {
       "post": {
-        "tags": ["Community"],
+        "tags": [
+          "Community"
+        ],
         "description": "",
         "parameters": [
           {
@@ -8007,7 +8077,10 @@
                   "value": {
                     "name": "My community name",
                     "description": "Description for your community",
-                    "groupIds": ["groupId1", "groupId2"]
+                    "groupIds": [
+                      "groupId1",
+                      "groupId2"
+                    ]
                   }
                 }
               }
@@ -8018,7 +8091,9 @@
     },
     "/api/{session}/deactivate-community": {
       "post": {
-        "tags": ["Community"],
+        "tags": [
+          "Community"
+        ],
         "description": "",
         "parameters": [
           {
@@ -8070,7 +8145,9 @@
     },
     "/api/{session}/add-community-subgroup": {
       "post": {
-        "tags": ["Community"],
+        "tags": [
+          "Community"
+        ],
         "description": "",
         "parameters": [
           {
@@ -8115,7 +8192,9 @@
                 "Default": {
                   "value": {
                     "id": "<you_community_id@g.us>",
-                    "groupsIds": ["group1Id@g.us"]
+                    "groupsIds": [
+                      "group1Id@g.us"
+                    ]
                   }
                 }
               }
@@ -8126,7 +8205,9 @@
     },
     "/api/{session}/remove-community-subgroup": {
       "post": {
-        "tags": ["Community"],
+        "tags": [
+          "Community"
+        ],
         "description": "",
         "parameters": [
           {
@@ -8171,7 +8252,9 @@
                 "Default": {
                   "value": {
                     "id": "<you_community_id@g.us>",
-                    "groupsIds": ["group1Id@g.us"]
+                    "groupsIds": [
+                      "group1Id@g.us"
+                    ]
                   }
                 }
               }
@@ -8182,7 +8265,9 @@
     },
     "/api/{session}/promote-community-participant": {
       "post": {
-        "tags": ["Community"],
+        "tags": [
+          "Community"
+        ],
         "description": "",
         "parameters": [
           {
@@ -8227,7 +8312,9 @@
                 "Default": {
                   "value": {
                     "id": "<you_community_id@g.us>",
-                    "participantsId": ["group1Id@g.us"]
+                    "participantsId": [
+                      "group1Id@g.us"
+                    ]
                   }
                 }
               }
@@ -8238,7 +8325,9 @@
     },
     "/api/{session}/demote-community-participant": {
       "post": {
-        "tags": ["Community"],
+        "tags": [
+          "Community"
+        ],
         "description": "",
         "parameters": [
           {
@@ -8283,7 +8372,9 @@
                 "Default": {
                   "value": {
                     "id": "<you_community_id@g.us>",
-                    "participantsId": ["group1Id@g.us"]
+                    "participantsId": [
+                      "group1Id@g.us"
+                    ]
                   }
                 }
               }
@@ -8294,7 +8385,9 @@
     },
     "/api/{session}/community-participants/{id}": {
       "get": {
-        "tags": ["Community"],
+        "tags": [
+          "Community"
+        ],
         "description": "",
         "parameters": [
           {
@@ -8556,7 +8649,9 @@
     },
     "/api/{session}/chatwoot": {
       "post": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "You can point your Chatwoot to this route so that it can perform functions.",
         "parameters": [
           {
@@ -8622,7 +8717,9 @@
     },
     "/healthz": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "This endpoint can be used to check the health status of the API. It returns a response with a status code indicating the API",
         "responses": {
           "default": {
@@ -8633,7 +8730,9 @@
     },
     "/unhealthy": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "This endpoint is used to force the API into an unhealthy state. It can be useful for testing error handling or simulating service disruptions.",
         "responses": {
           "default": {
@@ -8644,7 +8743,9 @@
     },
     "/metrics": {
       "get": {
-        "tags": ["Misc"],
+        "tags": [
+          "Misc"
+        ],
         "description": "This endpoint can be used to check the status of API metrics. It returns a response with the collected metrics.",
         "responses": {
           "default": {

--- a/src/tests/integration/callMediaBrowser.test.ts
+++ b/src/tests/integration/callMediaBrowser.test.ts
@@ -93,13 +93,53 @@ describe('Call media browser bridge', () => {
           };
         });
 
+        const baseline = await page.evaluate(async () => {
+          const test = (globalThis as any).__callMediaTest;
+          test.receiverTone.stop();
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          const report = await test.caller.getReceivers()[0].getStats();
+          const inbound = [...report.values()].find(
+            (entry: any) =>
+              entry.type === 'inbound-rtp' && entry.kind === 'audio'
+          );
+          return {
+            bytesReceived: inbound?.bytesReceived || 0,
+          };
+        });
+        const sampleRate = 16_000;
+        const tone = Buffer.alloc(sampleRate * 2);
+        for (let index = 0; index < sampleRate; index++) {
+          tone.writeInt16LE(
+            Math.round(
+              Math.sin((2 * Math.PI * 440 * index) / sampleRate) * 12_000
+            ),
+            index * 2
+          );
+        }
         await expect(
-          pushOutgoingPcm16(
-            page,
-            Buffer.alloc(3_200).toString('base64'),
-            16_000
-          )
+          pushOutgoingPcm16(page, tone.toString('base64'), sampleRate)
         ).resolves.toBe(true);
+        await new Promise((resolve) => setTimeout(resolve, 800));
+        const afterInjection = await page.evaluate(async () => {
+          const test = (globalThis as any).__callMediaTest;
+          const report = await test.caller.getReceivers()[0].getStats();
+          const inbound = [...report.values()].find(
+            (entry: any) =>
+              entry.type === 'inbound-rtp' && entry.kind === 'audio'
+          );
+          return {
+            bytesReceived: inbound?.bytesReceived || 0,
+            framesWritten: (globalThis as any).__wppconnectOutgoingAudio
+              ?.framesWritten,
+            lastPeak:
+              (globalThis as any).__wppconnectOutgoingAudio?.lastPeak || 0,
+          };
+        });
+        expect(afterInjection.bytesReceived).toBeGreaterThan(
+          baseline.bytesReceived
+        );
+        expect(afterInjection.framesWritten).toBe(sampleRate);
+        expect(afterInjection.lastPeak).toBeGreaterThan(0);
 
         const deadline = Date.now() + 10_000;
         while (!chunks.length && Date.now() < deadline) {

--- a/src/tests/integration/callMediaBrowser.test.ts
+++ b/src/tests/integration/callMediaBrowser.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { existsSync } from 'fs';
+import puppeteer from 'puppeteer';
+
+import {
+  IncomingCallAudioChunk,
+  installIncomingAudioCapture,
+  pushOutgoingPcm16,
+} from '../../util/callUtil';
+
+const chromePath = puppeteer.executablePath();
+const browserTest = existsSync(chromePath) ? it : it.skip;
+
+describe('Call media browser bridge', () => {
+  browserTest(
+    'captures a remote track and replaces an outgoing audio sender',
+    async () => {
+      const browser = await puppeteer.launch({
+        executablePath: chromePath,
+        headless: true,
+        args: ['--autoplay-policy=no-user-gesture-required', '--no-sandbox'],
+      });
+
+      try {
+        const page = await browser.newPage();
+        const chunks: IncomingCallAudioChunk[] = [];
+        await installIncomingAudioCapture(page, (chunk) => {
+          chunks.push(chunk);
+        });
+
+        await page.evaluate(async () => {
+          const caller = new RTCPeerConnection();
+          const receiver = new RTCPeerConnection();
+          const callerContext = new AudioContext();
+          await callerContext.resume();
+          const callerTone = callerContext.createOscillator();
+          const callerDestination =
+            callerContext.createMediaStreamDestination();
+          callerTone.connect(callerDestination);
+          const callerSink = callerContext.createGain();
+          callerSink.gain.value = 0;
+          callerTone.connect(callerSink).connect(callerContext.destination);
+          callerTone.start();
+          caller.addTrack(callerDestination.stream.getAudioTracks()[0]);
+
+          const receiverContext = new AudioContext();
+          await receiverContext.resume();
+          const receiverTone = receiverContext.createOscillator();
+          const receiverDestination =
+            receiverContext.createMediaStreamDestination();
+          receiverTone.connect(receiverDestination);
+          const receiverSink = receiverContext.createGain();
+          receiverSink.gain.value = 0;
+          receiverTone
+            .connect(receiverSink)
+            .connect(receiverContext.destination);
+          receiverTone.start();
+          receiver.addTrack(receiverDestination.stream.getAudioTracks()[0]);
+
+          caller.onicecandidate = ({ candidate }) => {
+            if (candidate) void receiver.addIceCandidate(candidate);
+          };
+          receiver.onicecandidate = ({ candidate }) => {
+            if (candidate) void caller.addIceCandidate(candidate);
+          };
+
+          await caller.setLocalDescription(await caller.createOffer());
+          await receiver.setRemoteDescription(caller.localDescription!);
+          await receiver.setLocalDescription(await receiver.createAnswer());
+          await caller.setRemoteDescription(receiver.localDescription!);
+
+          (globalThis as any).__callMediaTest = {
+            caller,
+            callerContext,
+            callerTone,
+            receiver,
+            receiverContext,
+            receiverTone,
+          };
+        });
+
+        await expect(
+          pushOutgoingPcm16(
+            page,
+            Buffer.alloc(3_200).toString('base64'),
+            16_000
+          )
+        ).resolves.toBe(true);
+
+        const deadline = Date.now() + 10_000;
+        while (!chunks.length && Date.now() < deadline) {
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        if (!chunks.length) {
+          const diagnostics = await page.evaluate(() => {
+            const scope = globalThis as any;
+            return {
+              capture:
+                scope.__wppconnectCallAudioCaptureDiagnostics || undefined,
+              connections: [
+                ...(scope.__wppconnectCallPeerConnections || []),
+              ].map((connection: RTCPeerConnection) => ({
+                connectionState: connection.connectionState,
+                receivers: connection.getReceivers().map((receiver) => ({
+                  kind: receiver.track.kind,
+                  muted: receiver.track.muted,
+                  readyState: receiver.track.readyState,
+                })),
+              })),
+              captures: [...(scope.__wppconnectCallAudioCaptures || [])].map(
+                (context: AudioContext) => ({
+                  sampleRate: context.sampleRate,
+                  state: context.state,
+                })
+              ),
+            };
+          });
+          throw new Error(
+            `No audio chunks produced: ${JSON.stringify(diagnostics)}`
+          );
+        }
+        expect(chunks.length).toBeGreaterThan(0);
+        expect(chunks[0].data.length).toBeGreaterThan(0);
+        expect(chunks[0].mimeType).toContain('audio');
+      } finally {
+        await browser.close();
+      }
+    },
+    30_000
+  );
+});

--- a/src/tests/integration/callMediaSocket.test.ts
+++ b/src/tests/integration/callMediaSocket.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createServer } from 'http';
+import { AddressInfo } from 'net';
+import { Server } from 'socket.io';
+import { io as connect, Socket as ClientSocket } from 'socket.io-client';
+
+import {
+  activateCallMedia,
+  callMediaRoom,
+  configureCallMediaNamespace,
+  createMediaTicket,
+  deactivateCallMedia,
+  emitIncomingAudio,
+  resetCallMediaForTests,
+} from '../../util/callMediaUtil';
+
+describe('Call media Socket.IO authorization', () => {
+  const clients: ClientSocket[] = [];
+  const http = createServer();
+  const server = new Server(http);
+  const namespace = server.of('/call-media');
+  let url: string;
+
+  beforeAll(async () => {
+    configureCallMediaNamespace(namespace);
+    await new Promise<void>((resolve) => http.listen(0, '127.0.0.1', resolve));
+    url = `http://127.0.0.1:${(http.address() as AddressInfo).port}/call-media`;
+  });
+
+  afterEach(() => {
+    clients.splice(0).forEach((client) => client.close());
+    resetCallMediaForTests({ preserveNamespace: true });
+  });
+
+  afterAll(async () => {
+    clients.splice(0).forEach((client) => client.close());
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  function open(ticket: string): ClientSocket {
+    const client = connect(url, {
+      auth: { ticket },
+      forceNew: true,
+      reconnection: false,
+      transports: ['websocket'],
+    });
+    clients.push(client);
+    return client;
+  }
+
+  it('rejects invalid and reused tickets', async () => {
+    const invalid = open('invalid');
+    await new Promise<void>((resolve) =>
+      invalid.once('connect_error', () => resolve())
+    );
+    expect(invalid.connected).toBe(false);
+
+    activateCallMedia('session-a', 'call-1');
+    const { ticket } = createMediaTicket('session-a', 'call-1');
+    const valid = open(ticket);
+    await new Promise<void>((resolve) => valid.once('connect', resolve));
+    expect(valid.connected).toBe(true);
+
+    const reused = open(ticket);
+    await new Promise<void>((resolve) =>
+      reused.once('connect_error', () => resolve())
+    );
+    expect(reused.connected).toBe(false);
+  });
+
+  it('delivers incoming audio only to the bound session and call room', async () => {
+    activateCallMedia('session-a', 'call-1');
+    const first = open(createMediaTicket('session-a', 'call-1').ticket);
+    await new Promise<void>((resolve) => first.once('connect', resolve));
+
+    activateCallMedia('session-b', 'call-2');
+    const second = open(createMediaTicket('session-b', 'call-2').ticket);
+    await new Promise<void>((resolve) => second.once('connect', resolve));
+
+    const received = new Promise<unknown>((resolve) =>
+      first.once('incoming-audio', resolve)
+    );
+    emitIncomingAudio('session-a', 'call-1', {
+      data: 'AA==',
+      mimeType: 'audio/pcm',
+      sequence: 1,
+      timestamp: 123,
+    });
+
+    await expect(received).resolves.toMatchObject({
+      callId: 'call-1',
+      data: 'AA==',
+    });
+    expect(
+      namespace.adapter.rooms.has(callMediaRoom('session-a', 'call-1'))
+    ).toBe(true);
+    expect(
+      namespace.adapter.rooms.has(callMediaRoom('session-b', 'call-2'))
+    ).toBe(true);
+
+    const disconnected = new Promise<void>((resolve) =>
+      first.once('disconnect', () => resolve())
+    );
+    deactivateCallMedia('session-a', 'call-1');
+    await disconnected;
+    expect(first.connected).toBe(false);
+    expect(second.connected).toBe(true);
+  });
+});

--- a/src/tests/integration/callMediaSocket.test.ts
+++ b/src/tests/integration/callMediaSocket.test.ts
@@ -24,6 +24,7 @@ import {
   configureCallMediaNamespace,
   createMediaTicket,
   deactivateCallMedia,
+  emitCallMediaEnded,
   emitIncomingAudio,
   resetCallMediaForTests,
 } from '../../util/callMediaUtil';
@@ -105,6 +106,11 @@ describe('Call media Socket.IO authorization', () => {
       callId: 'call-1',
       data: 'AA==',
     });
+    const ended = new Promise<unknown>((resolve) =>
+      first.once('call-media-ended', resolve)
+    );
+    emitCallMediaEnded('session-a', 'call-1');
+    await expect(ended).resolves.toMatchObject({ callId: 'call-1' });
     expect(
       namespace.adapter.rooms.has(callMediaRoom('session-a', 'call-1'))
     ).toBe(true);

--- a/src/tests/util/callMediaUtil.test.ts
+++ b/src/tests/util/callMediaUtil.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  consumeMediaTicket,
+  createMediaTicket,
+  resetCallMediaForTests,
+} from '../../util/callMediaUtil';
+
+describe('Call media authorization', () => {
+  afterEach(resetCallMediaForTests);
+
+  it('creates a session-bound, single-use ticket', () => {
+    const result = createMediaTicket('session-a');
+
+    expect(consumeMediaTicket(result.ticket)?.session).toBe('session-a');
+    expect(consumeMediaTicket(result.ticket)).toBeUndefined();
+  });
+
+  it('rejects expired and invalid ticket lifetimes', () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    const result = createMediaTicket('session-a', 1_000);
+    now.mockReturnValue(2_001);
+
+    expect(consumeMediaTicket(result.ticket)).toBeUndefined();
+    expect(() => createMediaTicket('session-a', Number.NaN)).toThrow(
+      'ttlMs must be a number'
+    );
+    now.mockRestore();
+  });
+});

--- a/src/tests/util/callMediaUtil.test.ts
+++ b/src/tests/util/callMediaUtil.test.ts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 import {
+  activateCallMedia,
+  callMediaRoom,
   consumeMediaTicket,
   createMediaTicket,
+  deactivateCallMedia,
   resetCallMediaForTests,
 } from '../../util/callMediaUtil';
 
@@ -23,19 +26,43 @@ describe('Call media authorization', () => {
   afterEach(resetCallMediaForTests);
 
   it('creates a session-bound, single-use ticket', () => {
-    const result = createMediaTicket('session-a');
+    activateCallMedia('session-a', 'call-1');
+    const result = createMediaTicket('session-a', 'call-1');
 
     expect(consumeMediaTicket(result.ticket)?.session).toBe('session-a');
     expect(consumeMediaTicket(result.ticket)).toBeUndefined();
+    expect(callMediaRoom('session-a', 'call-1')).toBe('session-a:call-1');
+  });
+
+  it('rejects tickets for an inactive call', () => {
+    expect(() => createMediaTicket('session-a', 'call-1')).toThrow(
+      'Call media is not active for this session and callId'
+    );
+    activateCallMedia('session-a', 'call-2');
+    expect(() => createMediaTicket('session-a', 'call-1')).toThrow(
+      'Call media is not active for this session and callId'
+    );
+  });
+
+  it('invalidates issued tickets when the active call changes or ends', () => {
+    activateCallMedia('session-a', 'call-1');
+    const replaced = createMediaTicket('session-a', 'call-1');
+    activateCallMedia('session-a', 'call-2');
+    expect(consumeMediaTicket(replaced.ticket)).toBeUndefined();
+
+    const ended = createMediaTicket('session-a', 'call-2');
+    deactivateCallMedia('session-a', 'call-2');
+    expect(consumeMediaTicket(ended.ticket)).toBeUndefined();
   });
 
   it('rejects expired and invalid ticket lifetimes', () => {
     const now = jest.spyOn(Date, 'now').mockReturnValue(1_000);
-    const result = createMediaTicket('session-a', 1_000);
+    activateCallMedia('session-a', 'call-1');
+    const result = createMediaTicket('session-a', 'call-1', 1_000);
     now.mockReturnValue(2_001);
 
     expect(consumeMediaTicket(result.ticket)).toBeUndefined();
-    expect(() => createMediaTicket('session-a', Number.NaN)).toThrow(
+    expect(() => createMediaTicket('session-a', 'call-1', Number.NaN)).toThrow(
       'ttlMs must be a number'
     );
     now.mockRestore();

--- a/src/tests/util/callUtil.test.ts
+++ b/src/tests/util/callUtil.test.ts
@@ -24,6 +24,7 @@ import {
   offerCall,
   pushOutgoingPcm16,
   stopIncomingAudioCapture,
+  stopOutgoingAudio,
 } from '../../util/callUtil';
 
 function mockPage(result: unknown = true) {
@@ -70,12 +71,13 @@ describe('Call utilities', () => {
 
     await installIncomingAudioCapture(page, onChunk, { timesliceMs: 500 });
     await stopIncomingAudioCapture(page);
+    await stopOutgoingAudio(page);
 
     expect(page.exposeFunction).toHaveBeenCalledWith(
       '__wppconnectIncomingCallAudioChunk',
       onChunk
     );
-    expect(page.evaluate).toHaveBeenCalledTimes(2);
+    expect(page.evaluate).toHaveBeenCalledTimes(3);
     expect(page.evaluate).toHaveBeenNthCalledWith(1, expect.any(Function), {
       callbackName: '__wppconnectIncomingCallAudioChunk',
       timesliceMs: 500,

--- a/src/tests/util/callUtil.test.ts
+++ b/src/tests/util/callUtil.test.ts
@@ -69,8 +69,14 @@ describe('Call utilities', () => {
     } as unknown as Page;
     const onChunk = jest.fn();
     const secondHandler = jest.fn();
+    const onEnded = jest.fn();
 
-    await installIncomingAudioCapture(page, onChunk, { timesliceMs: 500 });
+    await installIncomingAudioCapture(
+      page,
+      onChunk,
+      { timesliceMs: 500 },
+      onEnded
+    );
     await installIncomingAudioCapture(page, secondHandler, {
       timesliceMs: 500,
     });
@@ -83,13 +89,17 @@ describe('Call utilities', () => {
     await dispatch({ data: 'AA==', mimeType: 'audio/pcm', sequence: 0 });
     expect(onChunk).toHaveBeenCalled();
     expect(secondHandler).toHaveBeenCalled();
+    const dispatchEnded = (page.exposeFunction as jest.Mock).mock.calls[1][1];
+    await dispatchEnded();
+    expect(onEnded).toHaveBeenCalled();
 
     await stopIncomingAudioCapture(page);
     await stopOutgoingAudio(page);
-    expect(page.exposeFunction).toHaveBeenCalledTimes(1);
+    expect(page.exposeFunction).toHaveBeenCalledTimes(2);
     expect(page.evaluate).toHaveBeenCalledTimes(5);
     expect(page.evaluate).toHaveBeenNthCalledWith(1, expect.any(Function), {
       callbackName: '__wppconnectIncomingCallAudioChunk',
+      endedCallbackName: '__wppconnectIncomingCallAudioEnded',
       timesliceMs: 500,
     });
   });

--- a/src/tests/util/callUtil.test.ts
+++ b/src/tests/util/callUtil.test.ts
@@ -19,8 +19,10 @@ import {
   acceptCall,
   enableCallInterface,
   endCall,
+  installIncomingAudioCapture,
   normalizeCallDestination,
   offerCall,
+  stopIncomingAudioCapture,
 } from '../../util/callUtil';
 
 function mockPage(result: unknown = true) {
@@ -55,6 +57,27 @@ describe('Call utilities', () => {
     expect(page.evaluate).toHaveBeenLastCalledWith(expect.any(Function), {
       to: '5534999577020@c.us',
       isVideo: true,
+    });
+  });
+
+  it('installs and stops incoming audio capture in the browser', async () => {
+    const page = {
+      evaluate: jest.fn().mockResolvedValue(undefined),
+      exposeFunction: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Page;
+    const onChunk = jest.fn();
+
+    await installIncomingAudioCapture(page, onChunk, { timesliceMs: 500 });
+    await stopIncomingAudioCapture(page);
+
+    expect(page.exposeFunction).toHaveBeenCalledWith(
+      '__wppconnectIncomingCallAudioChunk',
+      onChunk
+    );
+    expect(page.evaluate).toHaveBeenCalledTimes(2);
+    expect(page.evaluate).toHaveBeenNthCalledWith(1, expect.any(Function), {
+      callbackName: '__wppconnectIncomingCallAudioChunk',
+      timesliceMs: 500,
     });
   });
 });

--- a/src/tests/util/callUtil.test.ts
+++ b/src/tests/util/callUtil.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Page } from 'puppeteer';
+
+import {
+  acceptCall,
+  enableCallInterface,
+  endCall,
+  normalizeCallDestination,
+  offerCall,
+} from '../../util/callUtil';
+
+function mockPage(result: unknown = true) {
+  return {
+    evaluate: jest.fn().mockResolvedValue(result),
+  } as unknown as Page;
+}
+
+describe('Call utilities', () => {
+  it('normalizes a phone number as a WhatsApp user id', () => {
+    expect(normalizeCallDestination('+55 (34) 99957-7020')).toBe(
+      '5534999577020@c.us'
+    );
+    expect(normalizeCallDestination('123@lid.us')).toBe('123@lid.us');
+  });
+
+  it('rejects an empty destination', () => {
+    expect(() => normalizeCallDestination('---')).toThrow(
+      'Parameter phone must contain a WhatsApp number'
+    );
+  });
+
+  it('delegates call controls to the browser page', async () => {
+    const page = mockPage();
+
+    await enableCallInterface(page);
+    await acceptCall(page, 'call-1');
+    await endCall(page, 'call-1');
+    await offerCall(page, '5534999577020', { isVideo: true });
+
+    expect(page.evaluate).toHaveBeenCalledTimes(4);
+    expect(page.evaluate).toHaveBeenLastCalledWith(expect.any(Function), {
+      to: '5534999577020@c.us',
+      isVideo: true,
+    });
+  });
+});

--- a/src/tests/util/callUtil.test.ts
+++ b/src/tests/util/callUtil.test.ts
@@ -68,8 +68,12 @@ describe('Call utilities', () => {
       exposeFunction: jest.fn().mockResolvedValue(undefined),
     } as unknown as Page;
     const onChunk = jest.fn();
+    const secondHandler = jest.fn();
 
     await installIncomingAudioCapture(page, onChunk, { timesliceMs: 500 });
+    await installIncomingAudioCapture(page, secondHandler, {
+      timesliceMs: 500,
+    });
     expect(page.exposeFunction).toHaveBeenCalledWith(
       '__wppconnectIncomingCallAudioChunk',
       expect.any(Function)
@@ -77,10 +81,12 @@ describe('Call utilities', () => {
     const dispatch = (page.exposeFunction as jest.Mock).mock.calls[0][1];
     await dispatch({ data: 'AA==', mimeType: 'audio/pcm', sequence: 0 });
     expect(onChunk).toHaveBeenCalled();
+    expect(secondHandler).toHaveBeenCalled();
 
     await stopIncomingAudioCapture(page);
     await stopOutgoingAudio(page);
-    expect(page.evaluate).toHaveBeenCalledTimes(3);
+    expect(page.exposeFunction).toHaveBeenCalledTimes(1);
+    expect(page.evaluate).toHaveBeenCalledTimes(4);
     expect(page.evaluate).toHaveBeenNthCalledWith(1, expect.any(Function), {
       callbackName: '__wppconnectIncomingCallAudioChunk',
       timesliceMs: 500,

--- a/src/tests/util/callUtil.test.ts
+++ b/src/tests/util/callUtil.test.ts
@@ -22,6 +22,7 @@ import {
   installIncomingAudioCapture,
   normalizeCallDestination,
   offerCall,
+  pushOutgoingPcm16,
   stopIncomingAudioCapture,
 } from '../../util/callUtil';
 
@@ -79,5 +80,31 @@ describe('Call utilities', () => {
       callbackName: '__wppconnectIncomingCallAudioChunk',
       timesliceMs: 500,
     });
+  });
+
+  it('pushes outgoing PCM16 audio into the browser bridge', async () => {
+    const page = mockPage(true);
+
+    await expect(pushOutgoingPcm16(page, 'AAECAw==', 16_000)).resolves.toBe(
+      true
+    );
+    expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      base64Data: 'AAECAw==',
+      sampleRate: 16_000,
+    });
+  });
+
+  it('rejects invalid outgoing audio settings', async () => {
+    const page = mockPage();
+
+    await expect(pushOutgoingPcm16(page, '')).rejects.toThrow(
+      'Audio data is required'
+    );
+    await expect(pushOutgoingPcm16(page, 'AA==', 100)).rejects.toThrow(
+      'sampleRate must be between 8000 and 48000'
+    );
+    await expect(pushOutgoingPcm16(page, 'A'.repeat(350_001))).rejects.toThrow(
+      'Audio chunk exceeds the 256 KiB limit'
+    );
   });
 });

--- a/src/tests/util/callUtil.test.ts
+++ b/src/tests/util/callUtil.test.ts
@@ -52,7 +52,7 @@ describe('Call utilities', () => {
 
     await enableCallInterface(page);
     await acceptCall(page, 'call-1');
-    await endCall(page, 'call-1');
+    await endCall(page);
     await offerCall(page, '5534999577020', { isVideo: true });
 
     expect(page.evaluate).toHaveBeenCalledTimes(4);
@@ -74,6 +74,7 @@ describe('Call utilities', () => {
     await installIncomingAudioCapture(page, secondHandler, {
       timesliceMs: 500,
     });
+    await installIncomingAudioCapture(page, undefined, { timesliceMs: 500 });
     expect(page.exposeFunction).toHaveBeenCalledWith(
       '__wppconnectIncomingCallAudioChunk',
       expect.any(Function)
@@ -86,7 +87,7 @@ describe('Call utilities', () => {
     await stopIncomingAudioCapture(page);
     await stopOutgoingAudio(page);
     expect(page.exposeFunction).toHaveBeenCalledTimes(1);
-    expect(page.evaluate).toHaveBeenCalledTimes(4);
+    expect(page.evaluate).toHaveBeenCalledTimes(5);
     expect(page.evaluate).toHaveBeenNthCalledWith(1, expect.any(Function), {
       callbackName: '__wppconnectIncomingCallAudioChunk',
       timesliceMs: 500,

--- a/src/tests/util/callUtil.test.ts
+++ b/src/tests/util/callUtil.test.ts
@@ -20,6 +20,7 @@ import {
   enableCallInterface,
   endCall,
   installIncomingAudioCapture,
+  installIncomingCallWatcher,
   normalizeCallDestination,
   offerCall,
   pushOutgoingPcm16,
@@ -101,6 +102,35 @@ describe('Call utilities', () => {
       callbackName: '__wppconnectIncomingCallAudioChunk',
       endedCallbackName: '__wppconnectIncomingCallAudioEnded',
       timesliceMs: 500,
+    });
+  });
+
+  it('installs a modern CallStore watcher and dispatches incoming calls', async () => {
+    const page = {
+      evaluate: jest.fn().mockResolvedValue(undefined),
+      exposeFunction: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Page;
+    const onCall = jest.fn();
+
+    await installIncomingCallWatcher(page, onCall);
+
+    expect(page.exposeFunction).toHaveBeenCalledWith(
+      '__wppconnectIncomingCallDetected',
+      expect.any(Function)
+    );
+    const dispatch = (page.exposeFunction as jest.Mock).mock.calls[0][1];
+    const call = {
+      id: 'call-modern-1',
+      peerJid: '110024831549535@lid',
+      offerTime: 123,
+      isVideo: false,
+      isGroup: false,
+      outgoing: false,
+    };
+    await dispatch(call);
+    expect(onCall).toHaveBeenCalledWith(call);
+    expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      callbackName: '__wppconnectIncomingCallDetected',
     });
   });
 

--- a/src/tests/util/callUtil.test.ts
+++ b/src/tests/util/callUtil.test.ts
@@ -70,13 +70,16 @@ describe('Call utilities', () => {
     const onChunk = jest.fn();
 
     await installIncomingAudioCapture(page, onChunk, { timesliceMs: 500 });
-    await stopIncomingAudioCapture(page);
-    await stopOutgoingAudio(page);
-
     expect(page.exposeFunction).toHaveBeenCalledWith(
       '__wppconnectIncomingCallAudioChunk',
-      onChunk
+      expect.any(Function)
     );
+    const dispatch = (page.exposeFunction as jest.Mock).mock.calls[0][1];
+    await dispatch({ data: 'AA==', mimeType: 'audio/pcm', sequence: 0 });
+    expect(onChunk).toHaveBeenCalled();
+
+    await stopIncomingAudioCapture(page);
+    await stopOutgoingAudio(page);
     expect(page.evaluate).toHaveBeenCalledTimes(3);
     expect(page.evaluate).toHaveBeenNthCalledWith(1, expect.any(Function), {
       callbackName: '__wppconnectIncomingCallAudioChunk',

--- a/src/util/callMediaUtil.ts
+++ b/src/util/callMediaUtil.ts
@@ -19,28 +19,81 @@ import { Namespace } from 'socket.io';
 import { IncomingCallAudioChunk } from './callUtil';
 
 interface MediaTicket {
+  callId: string;
   expiresAt: number;
   session: string;
 }
 
 const tickets = new Map<string, MediaTicket>();
+const activeCalls = new Map<string, string>();
 let mediaNamespace: Namespace | undefined;
+
+function roomFor(session: string, callId: string): string {
+  return `${session}:${callId}`;
+}
+
+function pruneExpiredTickets(): void {
+  const now = Date.now();
+  tickets.forEach((value, key) => {
+    if (value.expiresAt < now) tickets.delete(key);
+  });
+}
+
+export function activateCallMedia(session: string, callId: string): void {
+  const previousCallId = activeCalls.get(session);
+  if (previousCallId && previousCallId !== callId) {
+    deactivateCallMedia(session, previousCallId);
+  }
+  activeCalls.set(session, callId);
+}
+
+export function isCallMediaActive(session: string, callId: string): boolean {
+  return activeCalls.get(session) === callId;
+}
+
+export function deactivateCallMedia(session: string, callId?: string): void {
+  if (!callId || activeCalls.get(session) === callId) {
+    const activeCallId = callId || activeCalls.get(session);
+    activeCalls.delete(session);
+    tickets.forEach((value, key) => {
+      if (value.session === session && (!callId || value.callId === callId)) {
+        tickets.delete(key);
+      }
+    });
+    if (activeCallId) {
+      mediaNamespace
+        ?.in(roomFor(session, activeCallId))
+        .disconnectSockets(true);
+    }
+  }
+}
 
 export function createMediaTicket(
   session: string,
+  callId: string,
   ttlMs = 60_000
 ): { expiresAt: number; ticket: string } {
   if (!Number.isFinite(ttlMs)) throw new Error('ttlMs must be a number');
+  if (activeCalls.get(session) !== callId) {
+    throw new Error('Call media is not active for this session and callId');
+  }
+  pruneExpiredTickets();
   const ticket = randomBytes(32).toString('base64url');
   const expiresAt = Date.now() + Math.max(1_000, Math.min(ttlMs, 300_000));
-  tickets.set(ticket, { expiresAt, session });
+  tickets.set(ticket, { callId, expiresAt, session });
   return { expiresAt, ticket };
 }
 
 export function consumeMediaTicket(ticket: string): MediaTicket | undefined {
   const value = tickets.get(ticket);
   tickets.delete(ticket);
-  if (!value || value.expiresAt < Date.now()) return undefined;
+  if (
+    !value ||
+    value.expiresAt < Date.now() ||
+    activeCalls.get(value.session) !== value.callId
+  ) {
+    return undefined;
+  }
   return value;
 }
 
@@ -48,14 +101,43 @@ export function setCallMediaNamespace(namespace: Namespace): void {
   mediaNamespace = namespace;
 }
 
-export function emitIncomingAudio(
-  session: string,
-  chunk: IncomingCallAudioChunk
-): void {
-  mediaNamespace?.to(session).emit('incoming-audio', chunk);
+export function configureCallMediaNamespace(namespace: Namespace): void {
+  setCallMediaNamespace(namespace);
+  namespace.use((socket, next) => {
+    const ticket = String(socket.handshake.auth?.ticket || '');
+    const authorization = consumeMediaTicket(ticket);
+    if (!authorization) {
+      next(new Error('Invalid or expired media ticket'));
+      return;
+    }
+    socket.data.session = authorization.session;
+    socket.data.callId = authorization.callId;
+    next();
+  });
+  namespace.on('connection', (socket) => {
+    socket.join(
+      roomFor(String(socket.data.session), String(socket.data.callId))
+    );
+  });
 }
 
-export function resetCallMediaForTests(): void {
+export function emitIncomingAudio(
+  session: string,
+  callId: string,
+  chunk: IncomingCallAudioChunk
+): void {
+  if (activeCalls.get(session) !== callId) return;
+  mediaNamespace
+    ?.to(roomFor(session, callId))
+    .emit('incoming-audio', { callId, ...chunk });
+}
+
+export { roomFor as callMediaRoom };
+
+export function resetCallMediaForTests(
+  options: { preserveNamespace?: boolean } = {}
+): void {
   tickets.clear();
-  mediaNamespace = undefined;
+  activeCalls.clear();
+  if (!options.preserveNamespace) mediaNamespace = undefined;
 }

--- a/src/util/callMediaUtil.ts
+++ b/src/util/callMediaUtil.ts
@@ -16,7 +16,7 @@
 import { randomBytes } from 'crypto';
 import { Namespace } from 'socket.io';
 
-import { IncomingCallAudioChunk } from './callUtil';
+import type { IncomingCallAudioChunk } from './callUtil';
 
 interface MediaTicket {
   callId: string;

--- a/src/util/callMediaUtil.ts
+++ b/src/util/callMediaUtil.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { randomBytes } from 'crypto';
+import { Namespace } from 'socket.io';
+
+import { IncomingCallAudioChunk } from './callUtil';
+
+interface MediaTicket {
+  expiresAt: number;
+  session: string;
+}
+
+const tickets = new Map<string, MediaTicket>();
+let mediaNamespace: Namespace | undefined;
+
+export function createMediaTicket(
+  session: string,
+  ttlMs = 60_000
+): { expiresAt: number; ticket: string } {
+  if (!Number.isFinite(ttlMs)) throw new Error('ttlMs must be a number');
+  const ticket = randomBytes(32).toString('base64url');
+  const expiresAt = Date.now() + Math.max(1_000, Math.min(ttlMs, 300_000));
+  tickets.set(ticket, { expiresAt, session });
+  return { expiresAt, ticket };
+}
+
+export function consumeMediaTicket(ticket: string): MediaTicket | undefined {
+  const value = tickets.get(ticket);
+  tickets.delete(ticket);
+  if (!value || value.expiresAt < Date.now()) return undefined;
+  return value;
+}
+
+export function setCallMediaNamespace(namespace: Namespace): void {
+  mediaNamespace = namespace;
+}
+
+export function emitIncomingAudio(
+  session: string,
+  chunk: IncomingCallAudioChunk
+): void {
+  mediaNamespace?.to(session).emit('incoming-audio', chunk);
+}
+
+export function resetCallMediaForTests(): void {
+  tickets.clear();
+  mediaNamespace = undefined;
+}

--- a/src/util/callMediaUtil.ts
+++ b/src/util/callMediaUtil.ts
@@ -132,6 +132,14 @@ export function emitIncomingAudio(
     .emit('incoming-audio', { callId, ...chunk });
 }
 
+export function emitCallMediaEnded(session: string, callId: string): void {
+  if (activeCalls.get(session) !== callId) return;
+  mediaNamespace?.to(roomFor(session, callId)).emit('call-media-ended', {
+    callId,
+    timestamp: Date.now(),
+  });
+}
+
 export { roomFor as callMediaRoom };
 
 export function resetCallMediaForTests(

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -160,8 +160,37 @@ export async function acceptCall(
   callId?: string
 ): Promise<boolean> {
   return page.evaluate(
-    ({ callId }) =>
-      (globalThis as typeof globalThis & { WPP: any }).WPP.call.accept(callId),
+    async ({ callId }) => {
+      const scope = globalThis as typeof globalThis & { WPP: any };
+      const call = callId
+        ? scope.WPP.whatsapp.CallStore.get(callId)
+        : scope.WPP.whatsapp.CallStore.getModelsArray().find(
+            (item: any) => item.getState?.() === 3 && !item.outgoing
+          );
+      if (!call) return scope.WPP.call.accept(callId);
+
+      const state = call.getState?.();
+      const peerJid = call.peerJid;
+      const isLid = peerJid?.toString?.().endsWith('@lid');
+      if (state !== 3 && !isLid) return scope.WPP.call.accept(callId);
+
+      // WA-JS 4.4.3 still compares the current numeric incoming-ring state with
+      // the legacy string and its E2E preflight cannot process a LID. The call
+      // offer has already established the LID session, so adapt only for the
+      // duration of accept and restore both methods immediately afterwards.
+      const originalGetState = call.getState;
+      const originalIsGroupCall = peerJid?.isGroupCall;
+      if (state === 3) call.getState = () => 'INCOMING_RING';
+      if (isLid && originalIsGroupCall) peerJid.isGroupCall = () => true;
+      try {
+        return await scope.WPP.call.accept(callId || String(call.id));
+      } finally {
+        call.getState = originalGetState;
+        if (isLid && originalIsGroupCall) {
+          peerJid.isGroupCall = originalIsGroupCall;
+        }
+      }
+    },
     { callId }
   );
 }

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -180,14 +180,32 @@ export async function acceptCall(
       // duration of accept and restore both methods immediately afterwards.
       const originalGetState = call.getState;
       const originalIsGroupCall = peerJid?.isGroupCall;
+      const originalToString = peerJid?.toString;
+      let phoneNumber: string | undefined;
+      if (isLid) {
+        const entry = await scope.WPP.contact.getPnLidEntry(peerJid);
+        phoneNumber = entry?.phoneNumber?._serialized;
+      }
       if (state === 3) call.getState = () => 'INCOMING_RING';
       if (isLid && originalIsGroupCall) peerJid.isGroupCall = () => true;
+      if (phoneNumber && originalToString) {
+        peerJid.toString = () => phoneNumber;
+      }
       try {
-        return await scope.WPP.call.accept(callId || String(call.id));
+        const acceptance = scope.WPP.call.accept(callId || String(call.id));
+        return await Promise.race([
+          acceptance,
+          new Promise<boolean>((resolve) =>
+            setTimeout(() => resolve(true), 3_000)
+          ),
+        ]);
       } finally {
         call.getState = originalGetState;
         if (isLid && originalIsGroupCall) {
           peerJid.isGroupCall = originalIsGroupCall;
+        }
+        if (phoneNumber && originalToString) {
+          peerJid.toString = originalToString;
         }
       }
     },

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -246,8 +246,14 @@ export async function stopOutgoingAudio(page: Page): Promise<void> {
     const scope = globalThis as any;
     const bridge = scope.__wppconnectOutgoingAudio;
     if (!bridge) return;
-    bridge.queue.length = 0;
-    await bridge.context.close();
+    if (bridge.kind === 'generator') {
+      await bridge.writer.close();
+      bridge.track.stop();
+    } else {
+      bridge.queue.length = 0;
+      bridge.clock.stop();
+      await bridge.context.close();
+    }
     delete scope.__wppconnectOutgoingAudio;
   });
 }
@@ -283,11 +289,34 @@ export async function pushOutgoingPcm16(
           )
         : undefined;
       if (!connection) return false;
+      const sender = connection
+        .getSenders()
+        .find((item) => item.track?.kind === 'audio');
+      if (!sender) return false;
+
+      if (
+        !scope.__wppconnectOutgoingAudio &&
+        scope.MediaStreamTrackGenerator &&
+        scope.AudioData
+      ) {
+        const track = new scope.MediaStreamTrackGenerator({ kind: 'audio' });
+        scope.__wppconnectOutgoingAudio = {
+          framesWritten: 0,
+          kind: 'generator',
+          lastPeak: 0,
+          nextTimestamp: 0,
+          sampleRate,
+          track,
+          writer: track.writable.getWriter(),
+        };
+      }
 
       if (!scope.__wppconnectOutgoingAudio) {
         const context = new AudioContext({ sampleRate });
-        const source = context.createScriptProcessor(2048, 0, 1);
+        const source = context.createScriptProcessor(2048, 1, 1);
         const destination = context.createMediaStreamDestination();
+        const clock = context.createConstantSource();
+        clock.offset.value = 0;
         const queue: number[] = [];
         let offset = 0;
         source.onaudioprocess = (event) => {
@@ -300,11 +329,16 @@ export async function pushOutgoingPcm16(
             offset = 0;
           }
         };
+        clock.connect(source);
         source.connect(destination);
+        clock.start();
         await context.resume();
         scope.__wppconnectOutgoingAudio = {
+          kind: 'web-audio',
           context,
+          clock,
           destination,
+          sampleRate,
           get offset() {
             return offset;
           },
@@ -313,23 +347,70 @@ export async function pushOutgoingPcm16(
       }
 
       const bridge = scope.__wppconnectOutgoingAudio;
-      const binary = atob(base64Data);
-      for (let index = 0; index + 1 < binary.length; index += 2) {
-        const value =
-          binary.charCodeAt(index) | (binary.charCodeAt(index + 1) << 8);
-        bridge.queue.push((value > 32767 ? value - 65536 : value) / 32768);
+      if (bridge.sampleRate !== sampleRate) {
+        throw new Error(
+          `Cannot change sampleRate from ${bridge.sampleRate} to ${sampleRate} during a call`
+        );
       }
-      const bufferedSamples = bridge.queue.length - bridge.offset;
-      if (bufferedSamples > sampleRate * 5) {
-        bridge.queue.splice(bridge.offset, bufferedSamples - sampleRate * 5);
+      const binary = atob(base64Data);
+      let track: MediaStreamTrack;
+      if (bridge.kind === 'generator') {
+        const samples = new Int16Array(Math.floor(binary.length / 2));
+        let peak = 0;
+        for (let index = 0; index < samples.length; index++) {
+          const offset = index * 2;
+          const value =
+            binary.charCodeAt(offset) | (binary.charCodeAt(offset + 1) << 8);
+          samples[index] = value > 32767 ? value - 65536 : value;
+          peak = Math.max(peak, Math.abs(samples[index]));
+        }
+        bridge.lastPeak = peak;
+        track = bridge.track;
+        if (sender.track !== track) await sender.replaceTrack(track);
+
+        const frameSize = Math.max(1, Math.round(sampleRate / 50));
+        for (let offset = 0; offset < samples.length; offset += frameSize) {
+          const frame = samples.subarray(
+            offset,
+            Math.min(offset + frameSize, samples.length)
+          );
+          const audioData = new scope.AudioData({
+            data: frame,
+            format: 's16',
+            numberOfChannels: 1,
+            numberOfFrames: frame.length,
+            sampleRate,
+            timestamp: bridge.nextTimestamp,
+          });
+          bridge.nextTimestamp += Math.round(
+            (frame.length * 1_000_000) / sampleRate
+          );
+          try {
+            await bridge.writer.write(audioData);
+            bridge.framesWritten += frame.length;
+          } finally {
+            audioData.close();
+          }
+          if (offset + frameSize < samples.length) {
+            await new Promise((resolve) =>
+              setTimeout(resolve, (frame.length * 1_000) / sampleRate)
+            );
+          }
+        }
+      } else {
+        for (let index = 0; index + 1 < binary.length; index += 2) {
+          const value =
+            binary.charCodeAt(index) | (binary.charCodeAt(index + 1) << 8);
+          bridge.queue.push((value > 32767 ? value - 65536 : value) / 32768);
+        }
+        const bufferedSamples = bridge.queue.length - bridge.offset;
+        if (bufferedSamples > sampleRate * 5) {
+          bridge.queue.splice(bridge.offset, bufferedSamples - sampleRate * 5);
+        }
+        track = bridge.destination.stream.getAudioTracks()[0];
       }
 
-      const track = bridge.destination.stream.getAudioTracks()[0];
-      const sender = connection
-        .getSenders()
-        .find((item) => item.track?.kind === 'audio');
-      if (!sender) return false;
-      await sender.replaceTrack(track);
+      if (sender.track !== track) await sender.replaceTrack(track);
       return true;
     },
     { base64Data, sampleRate }

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -19,6 +19,19 @@ export interface CallOfferOptions {
   isVideo?: boolean;
 }
 
+export interface IncomingCallAudioChunk {
+  mimeType: string;
+  data: string;
+  sequence: number;
+  timestamp: number;
+}
+
+export interface IncomingAudioCaptureOptions {
+  timesliceMs?: number;
+}
+
+const AUDIO_CHUNK_CALLBACK = '__wppconnectIncomingCallAudioChunk';
+
 export function normalizeCallDestination(phone: string): string {
   const trimmed = phone.trim();
 
@@ -78,4 +91,94 @@ export async function offerCall(
       }),
     { to, isVideo: Boolean(options.isVideo) }
   );
+}
+
+/**
+ * Experimental incoming WebRTC audio capture. It must be installed before the
+ * call peer connection receives its remote track.
+ */
+export async function installIncomingAudioCapture(
+  page: Page,
+  onChunk: (chunk: IncomingCallAudioChunk) => void | Promise<void>,
+  options: IncomingAudioCaptureOptions = {}
+): Promise<void> {
+  try {
+    await page.exposeFunction(AUDIO_CHUNK_CALLBACK, onChunk);
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      !error.message.includes('already exists')
+    ) {
+      throw error;
+    }
+  }
+
+  const timesliceMs = Math.max(100, options.timesliceMs ?? 250);
+  await page.evaluate(
+    ({ callbackName, timesliceMs }) => {
+      const scope = globalThis as any;
+      if (scope.__wppconnectCallAudioCaptureInstalled) return;
+
+      scope.__wppconnectCallAudioCaptureInstalled = true;
+      scope.__wppconnectCallAudioRecorders = new Set<MediaRecorder>();
+      let sequence = 0;
+
+      const captureTrack = (track: MediaStreamTrack) => {
+        if (track.kind !== 'audio' || typeof MediaRecorder === 'undefined') {
+          return;
+        }
+
+        const stream = new MediaStream([track]);
+        const recorder = new MediaRecorder(stream);
+        scope.__wppconnectCallAudioRecorders.add(recorder);
+
+        recorder.addEventListener('dataavailable', async (event) => {
+          if (!event.data.size) return;
+          const bytes = new Uint8Array(await event.data.arrayBuffer());
+          let binary = '';
+          for (const byte of bytes) binary += String.fromCharCode(byte);
+          await scope[callbackName]({
+            mimeType: recorder.mimeType || event.data.type,
+            data: btoa(binary),
+            sequence: sequence++,
+            timestamp: Date.now(),
+          });
+        });
+        recorder.addEventListener('stop', () => {
+          scope.__wppconnectCallAudioRecorders.delete(recorder);
+        });
+        track.addEventListener('ended', () => recorder.stop(), { once: true });
+        recorder.start(timesliceMs);
+      };
+
+      const originalAddTrack = RTCPeerConnection.prototype.addEventListener;
+      const instrument = (connection: RTCPeerConnection) => {
+        if ((connection as any).__wppconnectAudioCaptureAttached) return;
+        (connection as any).__wppconnectAudioCaptureAttached = true;
+        originalAddTrack.call(connection, 'track', (event: Event) => {
+          captureTrack((event as RTCTrackEvent).track);
+        });
+      };
+
+      const originalSetRemoteDescription =
+        RTCPeerConnection.prototype.setRemoteDescription;
+      RTCPeerConnection.prototype.setRemoteDescription = function (...args) {
+        instrument(this);
+        return originalSetRemoteDescription.apply(this, args as any);
+      };
+    },
+    { callbackName: AUDIO_CHUNK_CALLBACK, timesliceMs }
+  );
+}
+
+export async function stopIncomingAudioCapture(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const scope = globalThis as any;
+    const recorders = scope.__wppconnectCallAudioRecorders as
+      | Set<MediaRecorder>
+      | undefined;
+    recorders?.forEach((recorder) => {
+      if (recorder.state !== 'inactive') recorder.stop();
+    });
+  });
 }

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -107,10 +107,18 @@ export async function installIncomingCallWatcher(
 
       store.on('add', (call: any) => void emit(call));
       store.on('change', (call: any) => void emit(call));
-      const nowSeconds = Date.now() / 1000;
-      store.getModelsArray().forEach((call: any) => {
-        if (Number(call.offerTime || 0) >= nowSeconds - 120) void emit(call);
-      });
+      const scan = () => {
+        const nowSeconds = Date.now() / 1000;
+        store.getModelsArray().forEach((call: any) => {
+          if (Number(call.offerTime || 0) >= nowSeconds - 120) void emit(call);
+        });
+      };
+      scan();
+
+      // Recent WhatsApp Web builds update CallStore without reliably emitting
+      // the Backbone-style add/change events. Keep a lightweight fallback scan
+      // so an incoming call cannot be missed; `seen` keeps delivery idempotent.
+      scope.__wppconnectIncomingCallWatcherTimer = setInterval(scan, 500);
     },
     { callbackName: INCOMING_CALL_CALLBACK }
   );

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -31,6 +31,10 @@ export interface IncomingAudioCaptureOptions {
 }
 
 const AUDIO_CHUNK_CALLBACK = '__wppconnectIncomingCallAudioChunk';
+const incomingAudioHandlers = new WeakMap<
+  Page,
+  Set<(chunk: IncomingCallAudioChunk) => void | Promise<void>>
+>();
 
 export function normalizeCallDestination(phone: string): string {
   const trimmed = phone.trim();
@@ -102,16 +106,29 @@ export async function installIncomingAudioCapture(
   onChunk: (chunk: IncomingCallAudioChunk) => void | Promise<void>,
   options: IncomingAudioCaptureOptions = {}
 ): Promise<void> {
-  try {
-    await page.exposeFunction(AUDIO_CHUNK_CALLBACK, onChunk);
-  } catch (error) {
-    if (
-      !(error instanceof Error) ||
-      !error.message.includes('already exists')
-    ) {
-      throw error;
+  let handlers = incomingAudioHandlers.get(page);
+  if (!handlers) {
+    handlers = new Set();
+    incomingAudioHandlers.set(page, handlers);
+    const dispatch = async (chunk: IncomingCallAudioChunk) => {
+      const activeHandlers = incomingAudioHandlers.get(page);
+      if (!activeHandlers) return;
+      await Promise.allSettled(
+        [...activeHandlers].map((handler) => handler(chunk))
+      );
+    };
+    try {
+      await page.exposeFunction(AUDIO_CHUNK_CALLBACK, dispatch);
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.includes('already exists')
+      ) {
+        throw error;
+      }
     }
   }
+  handlers.add(onChunk);
 
   const timesliceMs = Math.max(100, options.timesliceMs ?? 250);
   await page.evaluate(
@@ -213,6 +230,7 @@ export async function installIncomingAudioCapture(
 }
 
 export async function stopIncomingAudioCapture(page: Page): Promise<void> {
+  incomingAudioHandlers.delete(page);
   await page.evaluate(() => {
     const scope = globalThis as any;
     const captures = scope.__wppconnectCallAudioCaptures as

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -31,9 +31,14 @@ export interface IncomingAudioCaptureOptions {
 }
 
 const AUDIO_CHUNK_CALLBACK = '__wppconnectIncomingCallAudioChunk';
+const AUDIO_ENDED_CALLBACK = '__wppconnectIncomingCallAudioEnded';
 const incomingAudioHandlers = new WeakMap<
   Page,
   Set<(chunk: IncomingCallAudioChunk) => void | Promise<void>>
+>();
+const incomingAudioEndedHandlers = new WeakMap<
+  Page,
+  Set<() => void | Promise<void>>
 >();
 
 export function normalizeCallDestination(phone: string): string {
@@ -102,7 +107,8 @@ export async function offerCall(
 export async function installIncomingAudioCapture(
   page: Page,
   onChunk?: (chunk: IncomingCallAudioChunk) => void | Promise<void>,
-  options: IncomingAudioCaptureOptions = {}
+  options: IncomingAudioCaptureOptions = {},
+  onEnded?: () => void | Promise<void>
 ): Promise<void> {
   let handlers = incomingAudioHandlers.get(page);
   if (!handlers) {
@@ -125,12 +131,33 @@ export async function installIncomingAudioCapture(
         throw error;
       }
     }
+    const dispatchEnded = async () => {
+      const activeHandlers = incomingAudioEndedHandlers.get(page);
+      if (!activeHandlers) return;
+      await Promise.allSettled([...activeHandlers].map((handler) => handler()));
+    };
+    try {
+      await page.exposeFunction(AUDIO_ENDED_CALLBACK, dispatchEnded);
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.includes('already exists')
+      ) {
+        throw error;
+      }
+    }
   }
   if (onChunk) handlers.add(onChunk);
+  let endedHandlers = incomingAudioEndedHandlers.get(page);
+  if (!endedHandlers) {
+    endedHandlers = new Set();
+    incomingAudioEndedHandlers.set(page, endedHandlers);
+  }
+  if (onEnded) endedHandlers.add(onEnded);
 
   const timesliceMs = Math.max(100, options.timesliceMs ?? 250);
   await page.evaluate(
-    ({ callbackName, timesliceMs }) => {
+    ({ callbackName, endedCallbackName, timesliceMs }) => {
       const scope = globalThis as any;
       if (scope.__wppconnectCallAudioCaptureInstalled) return;
 
@@ -157,6 +184,18 @@ export async function installIncomingAudioCapture(
           context.sampleRate * (timesliceMs / 1000)
         );
         scope.__wppconnectCallAudioCaptures.add(context);
+        let ended = false;
+        const notifyEnded = async () => {
+          if (ended) return;
+          ended = true;
+          try {
+            await scope[endedCallbackName]();
+          } catch (error) {
+            scope.__wppconnectCallAudioCaptureDiagnostics.callbackErrors.push(
+              String(error)
+            );
+          }
+        };
 
         processor.onaudioprocess = async (event) => {
           scope.__wppconnectCallAudioCaptureDiagnostics.dataEvents++;
@@ -196,6 +235,7 @@ export async function installIncomingAudioCapture(
             source.disconnect();
             void context.close();
             scope.__wppconnectCallAudioCaptures.delete(context);
+            void notifyEnded();
           },
           { once: true }
         );
@@ -223,12 +263,17 @@ export async function installIncomingAudioCapture(
         return originalSetRemoteDescription.apply(this, args as any);
       };
     },
-    { callbackName: AUDIO_CHUNK_CALLBACK, timesliceMs }
+    {
+      callbackName: AUDIO_CHUNK_CALLBACK,
+      endedCallbackName: AUDIO_ENDED_CALLBACK,
+      timesliceMs,
+    }
   );
 }
 
 export async function stopIncomingAudioCapture(page: Page): Promise<void> {
   incomingAudioHandlers.delete(page);
+  incomingAudioEndedHandlers.delete(page);
   await page.evaluate(() => {
     const scope = globalThis as any;
     const captures = scope.__wppconnectCallAudioCaptures as

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -120,36 +120,70 @@ export async function installIncomingAudioCapture(
       if (scope.__wppconnectCallAudioCaptureInstalled) return;
 
       scope.__wppconnectCallAudioCaptureInstalled = true;
-      scope.__wppconnectCallAudioRecorders = new Set<MediaRecorder>();
+      scope.__wppconnectCallAudioCaptures = new Set<AudioContext>();
       scope.__wppconnectCallPeerConnections = new Set<RTCPeerConnection>();
+      scope.__wppconnectCallAudioCaptureDiagnostics = {
+        callbackErrors: [],
+        dataEvents: 0,
+      };
       let sequence = 0;
 
       const captureTrack = (track: MediaStreamTrack) => {
-        if (track.kind !== 'audio' || typeof MediaRecorder === 'undefined') {
-          return;
-        }
+        if (track.kind !== 'audio') return;
 
         const stream = new MediaStream([track]);
-        const recorder = new MediaRecorder(stream);
-        scope.__wppconnectCallAudioRecorders.add(recorder);
+        const context = new AudioContext();
+        const source = context.createMediaStreamSource(stream);
+        const processor = context.createScriptProcessor(2048, 1, 1);
+        const silentSink = context.createGain();
+        silentSink.gain.value = 0;
+        const samples: number[] = [];
+        const targetSamples = Math.round(
+          context.sampleRate * (timesliceMs / 1000)
+        );
+        scope.__wppconnectCallAudioCaptures.add(context);
 
-        recorder.addEventListener('dataavailable', async (event) => {
-          if (!event.data.size) return;
-          const bytes = new Uint8Array(await event.data.arrayBuffer());
+        processor.onaudioprocess = async (event) => {
+          scope.__wppconnectCallAudioCaptureDiagnostics.dataEvents++;
+          const input = event.inputBuffer.getChannelData(0);
+          for (const sample of input) samples.push(sample);
+          if (samples.length < targetSamples) return;
+
+          const chunk = samples.splice(0, targetSamples);
+          const pcm = new Int16Array(chunk.length);
+          for (let index = 0; index < pcm.length; index++) {
+            const sample = Math.max(-1, Math.min(1, chunk[index]));
+            pcm[index] = sample < 0 ? sample * 32768 : sample * 32767;
+          }
+          const bytes = new Uint8Array(pcm.buffer);
           let binary = '';
           for (const byte of bytes) binary += String.fromCharCode(byte);
-          await scope[callbackName]({
-            mimeType: recorder.mimeType || event.data.type,
-            data: btoa(binary),
-            sequence: sequence++,
-            timestamp: Date.now(),
-          });
-        });
-        recorder.addEventListener('stop', () => {
-          scope.__wppconnectCallAudioRecorders.delete(recorder);
-        });
-        track.addEventListener('ended', () => recorder.stop(), { once: true });
-        recorder.start(timesliceMs);
+          try {
+            await scope[callbackName]({
+              mimeType: `audio/pcm;rate=${context.sampleRate};encoding=signed-integer;bits=16`,
+              data: btoa(binary),
+              sequence: sequence++,
+              timestamp: Date.now(),
+            });
+          } catch (error) {
+            scope.__wppconnectCallAudioCaptureDiagnostics.callbackErrors.push(
+              String(error)
+            );
+          }
+        };
+        source.connect(processor);
+        processor.connect(silentSink).connect(context.destination);
+        void context.resume();
+        track.addEventListener(
+          'ended',
+          () => {
+            processor.disconnect();
+            source.disconnect();
+            void context.close();
+            scope.__wppconnectCallAudioCaptures.delete(context);
+          },
+          { once: true }
+        );
       };
 
       const originalAddTrack = RTCPeerConnection.prototype.addEventListener;
@@ -181,12 +215,24 @@ export async function installIncomingAudioCapture(
 export async function stopIncomingAudioCapture(page: Page): Promise<void> {
   await page.evaluate(() => {
     const scope = globalThis as any;
-    const recorders = scope.__wppconnectCallAudioRecorders as
-      | Set<MediaRecorder>
+    const captures = scope.__wppconnectCallAudioCaptures as
+      | Set<AudioContext>
       | undefined;
-    recorders?.forEach((recorder) => {
-      if (recorder.state !== 'inactive') recorder.stop();
+    captures?.forEach((context) => {
+      void context.close();
     });
+    captures?.clear();
+  });
+}
+
+export async function stopOutgoingAudio(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const scope = globalThis as any;
+    const bridge = scope.__wppconnectOutgoingAudio;
+    if (!bridge) return;
+    bridge.queue.length = 0;
+    await bridge.context.close();
+    delete scope.__wppconnectOutgoingAudio;
   });
 }
 
@@ -214,7 +260,11 @@ export async function pushOutgoingPcm16(
         | Set<RTCPeerConnection>
         | undefined;
       const connection = connections
-        ? [...connections].find((item) => item.connectionState !== 'closed')
+        ? [...connections].find(
+            (item) =>
+              item.connectionState !== 'closed' &&
+              item.getSenders().some((sender) => sender.track?.kind === 'audio')
+          )
         : undefined;
       if (!connection) return false;
 

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Page } from 'puppeteer';
+
+export interface CallOfferOptions {
+  isVideo?: boolean;
+}
+
+export function normalizeCallDestination(phone: string): string {
+  const trimmed = phone.trim();
+
+  if (/^\d+@(c|lid)\.us$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  const digits = trimmed.replace(/\D/g, '');
+  if (!digits) {
+    throw new Error('Parameter phone must contain a WhatsApp number');
+  }
+
+  return `${digits}@c.us`;
+}
+
+export async function enableCallInterface(page: Page): Promise<void> {
+  await page.evaluate(() =>
+    (
+      globalThis as typeof globalThis & { WPP: any }
+    ).WPP.call.enableCallInterface()
+  );
+}
+
+export async function acceptCall(
+  page: Page,
+  callId?: string
+): Promise<boolean> {
+  return page.evaluate(
+    ({ callId }) =>
+      (globalThis as typeof globalThis & { WPP: any }).WPP.call.accept(callId),
+    { callId }
+  );
+}
+
+export async function endCall(page: Page, callId?: string): Promise<boolean> {
+  return page.evaluate(
+    ({ callId }) =>
+      (globalThis as typeof globalThis & { WPP: any }).WPP.call.end(callId),
+    { callId }
+  );
+}
+
+/**
+ * Sends WhatsApp's call signalling offer. WA-JS does not attach or transport
+ * audio/video media tracks through this method.
+ */
+export async function offerCall(
+  page: Page,
+  phone: string,
+  options: CallOfferOptions = {}
+): Promise<unknown> {
+  const to = normalizeCallDestination(phone);
+  return page.evaluate(
+    ({ to, isVideo }) =>
+      (globalThis as typeof globalThis & { WPP: any }).WPP.call.offer(to, {
+        isVideo,
+      }),
+    { to, isVideo: Boolean(options.isVideo) }
+  );
+}

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -121,6 +121,7 @@ export async function installIncomingAudioCapture(
 
       scope.__wppconnectCallAudioCaptureInstalled = true;
       scope.__wppconnectCallAudioRecorders = new Set<MediaRecorder>();
+      scope.__wppconnectCallPeerConnections = new Set<RTCPeerConnection>();
       let sequence = 0;
 
       const captureTrack = (track: MediaStreamTrack) => {
@@ -155,6 +156,12 @@ export async function installIncomingAudioCapture(
       const instrument = (connection: RTCPeerConnection) => {
         if ((connection as any).__wppconnectAudioCaptureAttached) return;
         (connection as any).__wppconnectAudioCaptureAttached = true;
+        scope.__wppconnectCallPeerConnections.add(connection);
+        connection.addEventListener('connectionstatechange', () => {
+          if (connection.connectionState === 'closed') {
+            scope.__wppconnectCallPeerConnections.delete(connection);
+          }
+        });
         originalAddTrack.call(connection, 'track', (event: Event) => {
           captureTrack((event as RTCTrackEvent).track);
         });
@@ -181,4 +188,84 @@ export async function stopIncomingAudioCapture(page: Page): Promise<void> {
       if (recorder.state !== 'inactive') recorder.stop();
     });
   });
+}
+
+export async function pushOutgoingPcm16(
+  page: Page,
+  base64Data: string,
+  sampleRate = 48_000
+): Promise<boolean> {
+  if (!base64Data) throw new Error('Audio data is required');
+  if (base64Data.length > 350_000) {
+    throw new Error('Audio chunk exceeds the 256 KiB limit');
+  }
+  if (
+    !Number.isFinite(sampleRate) ||
+    sampleRate < 8_000 ||
+    sampleRate > 48_000
+  ) {
+    throw new Error('sampleRate must be between 8000 and 48000');
+  }
+
+  return page.evaluate(
+    async ({ base64Data, sampleRate }) => {
+      const scope = globalThis as any;
+      const connections = scope.__wppconnectCallPeerConnections as
+        | Set<RTCPeerConnection>
+        | undefined;
+      const connection = connections
+        ? [...connections].find((item) => item.connectionState !== 'closed')
+        : undefined;
+      if (!connection) return false;
+
+      if (!scope.__wppconnectOutgoingAudio) {
+        const context = new AudioContext({ sampleRate });
+        const source = context.createScriptProcessor(2048, 0, 1);
+        const destination = context.createMediaStreamDestination();
+        const queue: number[] = [];
+        let offset = 0;
+        source.onaudioprocess = (event) => {
+          const output = event.outputBuffer.getChannelData(0);
+          for (let index = 0; index < output.length; index++) {
+            output[index] = queue[offset++] ?? 0;
+          }
+          if (offset > 8_192) {
+            queue.splice(0, offset);
+            offset = 0;
+          }
+        };
+        source.connect(destination);
+        await context.resume();
+        scope.__wppconnectOutgoingAudio = {
+          context,
+          destination,
+          get offset() {
+            return offset;
+          },
+          queue,
+        };
+      }
+
+      const bridge = scope.__wppconnectOutgoingAudio;
+      const binary = atob(base64Data);
+      for (let index = 0; index + 1 < binary.length; index += 2) {
+        const value =
+          binary.charCodeAt(index) | (binary.charCodeAt(index + 1) << 8);
+        bridge.queue.push((value > 32767 ? value - 65536 : value) / 32768);
+      }
+      const bufferedSamples = bridge.queue.length - bridge.offset;
+      if (bufferedSamples > sampleRate * 5) {
+        bridge.queue.splice(bridge.offset, bufferedSamples - sampleRate * 5);
+      }
+
+      const track = bridge.destination.stream.getAudioTracks()[0];
+      const sender = connection
+        .getSenders()
+        .find((item) => item.track?.kind === 'audio');
+      if (!sender) return false;
+      await sender.replaceTrack(track);
+      return true;
+    },
+    { base64Data, sampleRate }
+  );
 }

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -30,8 +30,18 @@ export interface IncomingAudioCaptureOptions {
   timesliceMs?: number;
 }
 
+export interface BrowserIncomingCall {
+  id: string;
+  peerJid: string;
+  offerTime: number;
+  isVideo: boolean;
+  isGroup: boolean;
+  outgoing: boolean;
+}
+
 const AUDIO_CHUNK_CALLBACK = '__wppconnectIncomingCallAudioChunk';
 const AUDIO_ENDED_CALLBACK = '__wppconnectIncomingCallAudioEnded';
+const INCOMING_CALL_CALLBACK = '__wppconnectIncomingCallDetected';
 const incomingAudioHandlers = new WeakMap<
   Page,
   Set<(chunk: IncomingCallAudioChunk) => void | Promise<void>>
@@ -40,6 +50,71 @@ const incomingAudioEndedHandlers = new WeakMap<
   Page,
   Set<() => void | Promise<void>>
 >();
+const incomingCallHandlers = new WeakMap<
+  Page,
+  (call: BrowserIncomingCall) => void | Promise<void>
+>();
+
+/**
+ * Watches the modern WhatsApp CallStore directly. The legacy WAPI
+ * onIncomingCall hook no longer fires reliably on recent WhatsApp Web builds.
+ */
+export async function installIncomingCallWatcher(
+  page: Page,
+  onCall: (call: BrowserIncomingCall) => void | Promise<void>
+): Promise<void> {
+  incomingCallHandlers.set(page, onCall);
+  try {
+    await page.exposeFunction(
+      INCOMING_CALL_CALLBACK,
+      async (call: BrowserIncomingCall) => {
+        const handler = incomingCallHandlers.get(page);
+        if (handler) await handler(call);
+      }
+    );
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      !error.message.includes('already exists')
+    ) {
+      throw error;
+    }
+  }
+
+  await page.evaluate(
+    ({ callbackName }) => {
+      const scope = globalThis as any;
+      if (scope.__wppconnectIncomingCallWatcherInstalled) return;
+      const store = scope.WPP?.whatsapp?.CallStore;
+      if (!store) throw new Error('WhatsApp CallStore is not available');
+
+      scope.__wppconnectIncomingCallWatcherInstalled = true;
+      const seen = new Set<string>();
+      const serialize = (call: any): BrowserIncomingCall => ({
+        id: String(call.id || ''),
+        peerJid: call.peerJid?.toString?.() || String(call.peerJid || ''),
+        offerTime: Number(call.offerTime || 0),
+        isVideo: Boolean(call.isVideo),
+        isGroup: Boolean(call.isGroup),
+        outgoing: Boolean(call.outgoing),
+      });
+      const emit = async (call: any) => {
+        const value = serialize(call);
+        if (!value.id || value.outgoing || seen.has(value.id)) return;
+        seen.add(value.id);
+        await scope[callbackName](value);
+      };
+
+      store.on('add', (call: any) => void emit(call));
+      store.on('change', (call: any) => void emit(call));
+      const nowSeconds = Date.now() / 1000;
+      store.getModelsArray().forEach((call: any) => {
+        if (Number(call.offerTime || 0) >= nowSeconds - 120) void emit(call);
+      });
+    },
+    { callbackName: INCOMING_CALL_CALLBACK }
+  );
+}
 
 export function normalizeCallDestination(phone: string): string {
   const trimmed = phone.trim();

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -267,6 +267,7 @@ export async function getCallInterfaceDiagnostics(
     const directModules: Record<string, unknown> = {};
     let recentOngoingCalls: unknown[] = [];
     let voipInitState: unknown;
+    let audioImplementationConfig: unknown;
     const functionKeys = (value: any) =>
       value
         ? Object.keys(value)
@@ -290,6 +291,16 @@ export async function getCallInterfaceDiagnostics(
         'WAWebCallNotificationBus',
         'WAWebVoipHandleNativeCallEvent',
         'WAWebNotificationsCallNotification',
+        'WAWebVoipAudioCaptureAndPlayback',
+        'WAWebVoipAudioCaptureBase',
+        'WAWebVoipAudioCaptureScriptProcessor',
+        'WAWebVoipAudioCaptureSharedBufferWorklet',
+        'WAWebVoipAudioPlaybackBase',
+        'WAWebVoipAudioPlaybackScriptProcessor',
+        'WAWebVoipAudioPlaybackSharedBufferWorklet',
+        'WAWebVoipBridgeMediaStreamHandlers',
+        'WAWebVoipBridgeMediaStreamHelpers',
+        'WAWebVoipABPropConfig',
       ]) {
         try {
           const module = scope.importNamespace?.(id) || scope.require?.(id);
@@ -306,6 +317,12 @@ export async function getCallInterfaceDiagnostics(
                         value && typeof value === 'object'
                           ? Object.keys(value).sort()
                           : [],
+                      classMethods:
+                        typeof value === 'function' && (value as any).prototype
+                          ? Object.getOwnPropertyNames((value as any).prototype)
+                              .filter((name) => name !== 'constructor')
+                              .sort()
+                          : [],
                       prototypeMethods:
                         value &&
                         (typeof value === 'object' ||
@@ -313,11 +330,7 @@ export async function getCallInterfaceDiagnostics(
                           ? Object.getOwnPropertyNames(
                               Object.getPrototypeOf(value) || {}
                             )
-                              .filter(
-                                (name) =>
-                                  name !== 'constructor' &&
-                                  typeof (value as any)[name] === 'function'
-                              )
+                              .filter((name) => name !== 'constructor')
                               .sort()
                           : [],
                     },
@@ -330,6 +343,29 @@ export async function getCallInterfaceDiagnostics(
             error: error instanceof Error ? error.message : String(error),
           };
         }
+      }
+      try {
+        const abProps =
+          scope.importNamespace?.('WAWebABProps') ||
+          scope.require?.('WAWebABProps');
+        const configuredGetter = abProps?.getABPropConfigValue;
+        const originalGetter = configuredGetter?.__wppconnectOriginal;
+        audioImplementationConfig = {
+          capture: configuredGetter?.('web_voip_audio_capture_impl'),
+          playback: configuredGetter?.('web_voip_audio_playback_impl'),
+          originalCapture: originalGetter?.call(
+            abProps,
+            'web_voip_audio_capture_impl'
+          ),
+          originalPlayback: originalGetter?.call(
+            abProps,
+            'web_voip_audio_playback_impl'
+          ),
+        };
+      } catch (error) {
+        audioImplementationConfig = {
+          error: error instanceof Error ? error.message : String(error),
+        };
       }
       try {
         const ongoingModule =
@@ -416,6 +452,21 @@ export async function getCallInterfaceDiagnostics(
         : [],
       recentOngoingCalls,
       voipInitState,
+      audioImplementationConfig,
+      voipScriptBridge: scope.__wppconnectVoipScriptBridge
+        ? {
+            captureProcessor: Boolean(
+              scope.__wppconnectVoipScriptBridge.captureProcessor
+            ),
+            captureSampleRate:
+              scope.__wppconnectVoipScriptBridge.captureSampleRate,
+            outgoingQueued:
+              scope.__wppconnectVoipScriptBridge.outgoingQueue?.length || 0,
+            playbackQueued:
+              scope.__wppconnectVoipScriptBridge.playbackSamples?.length || 0,
+          }
+        : null,
+      captureDiagnostics: scope.__wppconnectCallAudioCaptureDiagnostics || null,
       whatsappVoipKeys: whatsapp
         ? Object.keys(whatsapp)
             .filter((key) => /voip|call/i.test(key))
@@ -535,11 +586,24 @@ export async function acceptCall(
         }
         answerButton.click();
         if (!(await waitForPeerConnection())) {
-          throw new Error(
-            `Native WhatsApp answer button was clicked but WebRTC did not connect (control=${labelOf(
-              answerButton
-            )})`
+          const activeCallPattern =
+            /\b(desligar|encerrar|hang\s*up|end\s*call|mute|silenciar\s+microfone)\b/i;
+          const activeCallVisible = [
+            ...document.querySelectorAll<HTMLElement>(
+              'button, [role="button"]'
+            ),
+          ].some(
+            (element) =>
+              activeCallPattern.test(labelOf(element)) &&
+              element.getClientRects().length > 0
           );
+          if (!activeCallVisible) {
+            throw new Error(
+              `Native WhatsApp answer button was clicked but the call did not become active (control=${labelOf(
+                answerButton
+              )})`
+            );
+          }
         }
         return true;
       }
@@ -694,7 +758,165 @@ export async function installIncomingAudioCapture(
         callbackErrors: [],
         dataEvents: 0,
       };
+      scope.__wppconnectVoipScriptBridge = {
+        captureProcessor: null,
+        captureSampleRate: 48_000,
+        outgoingQueue: [],
+        outgoingStarted: false,
+        lastOutgoingSample: 0,
+        playbackSamples: [],
+      };
       let sequence = 0;
+
+      const emitPlaybackSamples = async (
+        input: Float32Array,
+        sampleRate: number
+      ) => {
+        const bridge = scope.__wppconnectVoipScriptBridge;
+        for (const sample of input) bridge.playbackSamples.push(sample);
+        const targetSamples = Math.round(sampleRate * (timesliceMs / 1000));
+        if (bridge.playbackSamples.length < targetSamples) return;
+        const chunk = bridge.playbackSamples.splice(0, targetSamples);
+        const pcm = new Int16Array(chunk.length);
+        for (let index = 0; index < pcm.length; index++) {
+          const sample = Math.max(-1, Math.min(1, chunk[index]));
+          pcm[index] = sample < 0 ? sample * 32768 : sample * 32767;
+        }
+        const bytes = new Uint8Array(pcm.buffer);
+        let binary = '';
+        for (const byte of bytes) binary += String.fromCharCode(byte);
+        try {
+          await scope[callbackName]({
+            mimeType: `audio/pcm;rate=${sampleRate};encoding=signed-integer;bits=16`,
+            data: btoa(binary),
+            sequence: sequence++,
+            timestamp: Date.now(),
+          });
+        } catch (error) {
+          scope.__wppconnectCallAudioCaptureDiagnostics.callbackErrors.push(
+            String(error)
+          );
+        }
+      };
+
+      const wrapScriptProcessor = (
+        instance: any,
+        property: string,
+        direction: 'capture' | 'playback'
+      ) => {
+        const processor = instance[property] as ScriptProcessorNode | null;
+        if (!processor || (processor as any).__wppconnectWrapped) return;
+        (processor as any).__wppconnectWrapped = true;
+        const original = processor.onaudioprocess;
+        if (direction === 'capture') {
+          const bridge = scope.__wppconnectVoipScriptBridge;
+          bridge.captureProcessor = processor;
+          bridge.captureSampleRate = processor.context.sampleRate;
+          processor.onaudioprocess = (event) => {
+            const input = event.inputBuffer.getChannelData(0);
+            const prebufferSamples = Math.round(
+              bridge.captureSampleRate * 0.12
+            );
+            if (
+              !bridge.outgoingStarted &&
+              bridge.outgoingQueue.length >= prebufferSamples
+            ) {
+              bridge.outgoingStarted = true;
+            }
+            for (let index = 0; index < input.length; index++) {
+              if (!bridge.outgoingStarted) {
+                input[index] = 0;
+                continue;
+              }
+              const queued = bridge.outgoingQueue.shift();
+              if (queued == null) {
+                const remaining = input.length - index;
+                for (let fade = index; fade < input.length; fade++) {
+                  input[fade] =
+                    bridge.lastOutgoingSample *
+                    ((input.length - fade - 1) / Math.max(1, remaining));
+                }
+                bridge.lastOutgoingSample = 0;
+                bridge.outgoingStarted = false;
+                break;
+              }
+              input[index] = queued;
+              bridge.lastOutgoingSample = queued;
+            }
+            original?.call(processor, event);
+          };
+        } else {
+          processor.onaudioprocess = (event) => {
+            original?.call(processor, event);
+            const output = event.outputBuffer.getChannelData(0);
+            scope.__wppconnectCallAudioCaptureDiagnostics.dataEvents++;
+            void emitPlaybackSamples(output, processor.context.sampleRate);
+          };
+        }
+      };
+
+      try {
+        const abProps =
+          scope.importNamespace?.('WAWebABProps') ||
+          scope.require?.('WAWebABProps');
+        if (
+          abProps?.getABPropConfigValue &&
+          !abProps.getABPropConfigValue.__wppconnectOriginal
+        ) {
+          const originalGetABProp = abProps.getABPropConfigValue;
+          const replacement = function (
+            this: any,
+            key: string,
+            ...args: unknown[]
+          ) {
+            if (
+              key === 'web_voip_audio_capture_impl' ||
+              key === 'web_voip_audio_playback_impl'
+            ) {
+              return 1;
+            }
+            return originalGetABProp.call(this, key, ...args);
+          };
+          replacement.__wppconnectOriginal = originalGetABProp;
+          abProps.getABPropConfigValue = replacement;
+        }
+
+        const captureModule =
+          scope.importNamespace?.('WAWebVoipAudioCaptureScriptProcessor') ||
+          scope.require?.('WAWebVoipAudioCaptureScriptProcessor');
+        const capturePrototype =
+          captureModule?.WAWebVoipAudioCaptureScriptProcessor?.prototype;
+        if (capturePrototype && !capturePrototype.__wppconnectWrapped) {
+          capturePrototype.__wppconnectWrapped = true;
+          const originalStart = capturePrototype.startAudioCapture;
+          capturePrototype.startAudioCapture = async function (...args: any[]) {
+            const result = await originalStart.apply(this, args);
+            wrapScriptProcessor(this, 'scriptProcessor', 'capture');
+            return result;
+          };
+        }
+
+        const playbackModule =
+          scope.importNamespace?.('WAWebVoipAudioPlaybackScriptProcessor') ||
+          scope.require?.('WAWebVoipAudioPlaybackScriptProcessor');
+        const playbackPrototype =
+          playbackModule?.WAWebVoipAudioPlaybackScriptProcessor?.prototype;
+        if (playbackPrototype && !playbackPrototype.__wppconnectWrapped) {
+          playbackPrototype.__wppconnectWrapped = true;
+          const originalStart = playbackPrototype.startAudioPlayback;
+          playbackPrototype.startAudioPlayback = async function (
+            ...args: any[]
+          ) {
+            const result = await originalStart.apply(this, args);
+            wrapScriptProcessor(this, 'playbackScriptProcessor', 'playback');
+            return result;
+          };
+        }
+      } catch (error) {
+        scope.__wppconnectCallAudioCaptureDiagnostics.callbackErrors.push(
+          `voip-script-bridge: ${String(error)}`
+        );
+      }
 
       const captureTrack = (track: MediaStreamTrack) => {
         if (track.kind !== 'audio') return;
@@ -849,6 +1071,37 @@ export async function pushOutgoingPcm16(
   return page.evaluate(
     async ({ base64Data, sampleRate }) => {
       const scope = globalThis as any;
+      const voipBridge = scope.__wppconnectVoipScriptBridge;
+      if (voipBridge?.captureProcessor) {
+        const binary = atob(base64Data);
+        const input = new Int16Array(Math.floor(binary.length / 2));
+        for (let index = 0; index < input.length; index++) {
+          const offset = index * 2;
+          const value =
+            binary.charCodeAt(offset) | (binary.charCodeAt(offset + 1) << 8);
+          input[index] = value > 32767 ? value - 65536 : value;
+        }
+        const outputRate = Number(voipBridge.captureSampleRate || 48_000);
+        const outputLength = Math.max(
+          1,
+          Math.round((input.length * outputRate) / sampleRate)
+        );
+        for (let index = 0; index < outputLength; index++) {
+          const sourcePosition = (index * sampleRate) / outputRate;
+          const left = Math.min(input.length - 1, Math.floor(sourcePosition));
+          const right = Math.min(input.length - 1, left + 1);
+          const fraction = sourcePosition - left;
+          const sample = input[left] * (1 - fraction) + input[right] * fraction;
+          voipBridge.outgoingQueue.push(sample / 32768);
+        }
+        if (voipBridge.outgoingQueue.length > outputRate * 5) {
+          voipBridge.outgoingQueue.splice(
+            0,
+            voipBridge.outgoingQueue.length - outputRate * 5
+          );
+        }
+        return true;
+      }
       const connections = scope.__wppconnectCallPeerConnections as
         | Set<RTCPeerConnection>
         | undefined;

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -852,17 +852,29 @@ export async function pushOutgoingPcm16(
       const connections = scope.__wppconnectCallPeerConnections as
         | Set<RTCPeerConnection>
         | undefined;
-      const connection = connections
-        ? [...connections].find(
-            (item) =>
-              item.connectionState !== 'closed' &&
-              item.getSenders().some((sender) => sender.track?.kind === 'audio')
-          )
-        : undefined;
+      const candidates = connections ? [...connections] : [];
+      const audioSenderFor = (item: RTCPeerConnection) =>
+        item.getSenders().find((sender) => sender.track?.kind === 'audio') ||
+        item
+          .getTransceivers()
+          .find(
+            (transceiver) =>
+              transceiver.receiver.track?.kind === 'audio' ||
+              transceiver.sender.track?.kind === 'audio'
+          )?.sender;
+      const connection =
+        candidates.find(
+          (item) =>
+            (item.connectionState === 'connected' ||
+              item.iceConnectionState === 'connected' ||
+              item.iceConnectionState === 'completed') &&
+            audioSenderFor(item)
+        ) ||
+        candidates.find(
+          (item) => item.connectionState !== 'closed' && audioSenderFor(item)
+        );
       if (!connection) return false;
-      const sender = connection
-        .getSenders()
-        .find((item) => item.track?.kind === 'audio');
+      const sender = audioSenderFor(connection);
       if (!sender) return false;
 
       if (

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -140,11 +140,19 @@ export function normalizeCallDestination(phone: string): string {
 }
 
 export async function enableCallInterface(page: Page): Promise<void> {
-  await page.evaluate(() =>
-    (
+  await page.evaluate(async () => {
+    const activation = (
       globalThis as typeof globalThis & { WPP: any }
-    ).WPP.call.enableCallInterface()
-  );
+    ).WPP.call.enableCallInterface();
+
+    // On current WhatsApp Web builds WA-JS applies the call interface but its
+    // promise may remain pending indefinitely. Do not block the HTTP request
+    // (and consequently auto-answer) after the activation was dispatched.
+    await Promise.race([
+      Promise.resolve(activation),
+      new Promise<void>((resolve) => setTimeout(resolve, 3_000)),
+    ]);
+  });
 }
 
 export async function acceptCall(

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -87,12 +87,25 @@ export async function installIncomingCallWatcher(
       if (scope.__wppconnectIncomingCallWatcherInstalled) return;
       const store = scope.WPP?.whatsapp?.CallStore;
       if (!store) throw new Error('WhatsApp CallStore is not available');
+      let ongoingStore: any;
+      try {
+        const module =
+          scope.importNamespace?.('WAWebVoipOngoingCallCollection') ||
+          scope.require?.('WAWebVoipOngoingCallCollection');
+        ongoingStore = module?.WAWebVoipOngoingCallCollection;
+      } catch {
+        ongoingStore = undefined;
+      }
 
       scope.__wppconnectIncomingCallWatcherInstalled = true;
       const seen = new Set<string>();
       const serialize = (call: any): BrowserIncomingCall => ({
-        id: String(call.id || ''),
-        peerJid: call.peerJid?.toString?.() || String(call.peerJid || ''),
+        id: String(call.id || call.callId || call.getCallId?.() || ''),
+        peerJid:
+          call.peerJid?.toString?.() ||
+          call.peerWid?.toString?.() ||
+          call.chatId?.toString?.() ||
+          String(call.peerJid || call.peerWid || call.chatId || ''),
         offerTime: Number(call.offerTime || 0),
         isVideo: Boolean(call.isVideo),
         isGroup: Boolean(call.isGroup),
@@ -107,11 +120,60 @@ export async function installIncomingCallWatcher(
 
       store.on('add', (call: any) => void emit(call));
       store.on('change', (call: any) => void emit(call));
+      ongoingStore?.on?.('add', (call: any) => void emit(call));
+      ongoingStore?.on?.('change', (call: any) => void emit(call));
+      const modelsOf = (collection: any): any[] => {
+        if (!collection) return [];
+        if (typeof collection.getModelsArray === 'function') {
+          return collection.getModelsArray();
+        }
+        if (Array.isArray(collection.models)) return collection.models;
+        const models = collection._models;
+        if (models instanceof Map) return [...models.values()];
+        if (Array.isArray(models)) return models;
+        return models && typeof models === 'object'
+          ? Object.values(models)
+          : [];
+      };
       const scan = () => {
         const nowSeconds = Date.now() / 1000;
         store.getModelsArray().forEach((call: any) => {
           if (Number(call.offerTime || 0) >= nowSeconds - 120) void emit(call);
         });
+        modelsOf(ongoingStore).forEach((call: any) => void emit(call));
+
+        // The native VoIP UI is the authoritative incoming-call surface on
+        // current WhatsApp Web builds. Some offers are rendered there without
+        // being mirrored to either exported call collection.
+        const nativeAnswerVisible = [
+          ...document.querySelectorAll<HTMLElement>('button, [role="button"]'),
+        ].some((element) => {
+          const label = [
+            element.getAttribute('aria-label'),
+            element.getAttribute('title'),
+            element.textContent,
+          ]
+            .filter(Boolean)
+            .join(' ');
+          return (
+            /\b(atender|aceitar|answer|accept)\b/i.test(label) &&
+            element.getClientRects().length > 0 &&
+            getComputedStyle(element).visibility !== 'hidden'
+          );
+        });
+        if (nativeAnswerVisible && !scope.__wppconnectNativeIncomingVisible) {
+          scope.__wppconnectNativeIncomingVisible = true;
+          void emit({
+            id: `native-ui-${Date.now()}`,
+            peerJid: '',
+            offerTime: Date.now() / 1000,
+            isVideo: false,
+            isGroup: false,
+            outgoing: false,
+          });
+        } else if (!nativeAnswerVisible) {
+          scope.__wppconnectNativeIncomingVisible = false;
+        }
       };
       scan();
 
@@ -141,6 +203,7 @@ export function normalizeCallDestination(phone: string): string {
 
 export async function enableCallInterface(page: Page): Promise<void> {
   await page.evaluate(async () => {
+    const scope = globalThis as any;
     const activation = (
       globalThis as typeof globalThis & { WPP: any }
     ).WPP.call.enableCallInterface();
@@ -152,6 +215,232 @@ export async function enableCallInterface(page: Page): Promise<void> {
       Promise.resolve(activation),
       new Promise<void>((resolve) => setTimeout(resolve, 3_000)),
     ]);
+
+    // WA-JS currently discovers Meta modules by their exported function
+    // shape. Recent WhatsApp builds register the VoIP modules by stable Meta
+    // identifiers but wrap their exports, so the shape lookup can remain
+    // unresolved. Fall back to the official module identifiers and initialize
+    // the backend explicitly.
+    const importModule = (id: string) => {
+      try {
+        return scope.importNamespace?.(id) || scope.require?.(id);
+      } catch {
+        return undefined;
+      }
+    };
+    const loadable = importModule('WAWebVoipBackendLoadable');
+    const requireBackend =
+      loadable?.requireVoipJsBackend ||
+      loadable?.default?.requireVoipJsBackend ||
+      (typeof loadable?.default === 'function' ? loadable.default : undefined);
+    let backend: any;
+    if (typeof requireBackend === 'function') {
+      backend = await requireBackend();
+    }
+    const initModule = backend?.WAWebVoipInit || importModule('WAWebVoipInit');
+    const initialize =
+      initModule?.initWAWebVoip || initModule?.default?.initWAWebVoip;
+    if (typeof initialize === 'function') {
+      await initialize();
+    }
+    const ensureModule = importModule('WAWebEnsureVoipInited');
+    const ensureInitialized =
+      ensureModule?.ensureVoipInitialized ||
+      ensureModule?.default?.ensureVoipInitialized;
+    if (typeof ensureInitialized === 'function') {
+      await ensureInitialized();
+    }
+  });
+}
+
+export async function getCallInterfaceDiagnostics(
+  page: Page
+): Promise<unknown> {
+  return page.evaluate(async () => {
+    const scope = globalThis as any;
+    const whatsapp = scope.WPP?.whatsapp;
+    let backend: any;
+    let backendError: string | undefined;
+    let stack: any;
+    let stackError: string | undefined;
+    let matchingModuleIds: string[] = [];
+    const directModules: Record<string, unknown> = {};
+    let recentOngoingCalls: unknown[] = [];
+    let voipInitState: unknown;
+    const functionKeys = (value: any) =>
+      value
+        ? Object.keys(value)
+            .filter((key) => typeof value[key] === 'function')
+            .sort()
+        : [];
+    try {
+      const modulesMap = scope.require?.('__debug')?.modulesMap || {};
+      matchingModuleIds = Object.keys(modulesMap)
+        .filter((id) => /voip|call/i.test(id))
+        .sort();
+      for (const id of [
+        'WAWebVoipBackendLoadable',
+        'WAWebVoipInit',
+        'WAWebEnsureVoipInited',
+        'WAWebVoipStackInterface',
+        'WAWebVoipStackInterfaceImpl',
+        'WAWebVoipOngoingCallCollection',
+        'WAWebVoipLocalCallStateStore',
+        'WAWebVoipInitEventEmitter',
+        'WAWebCallNotificationBus',
+        'WAWebVoipHandleNativeCallEvent',
+        'WAWebNotificationsCallNotification',
+      ]) {
+        try {
+          const module = scope.importNamespace?.(id) || scope.require?.(id);
+          directModules[id] = {
+            keys: module ? Object.keys(module).sort() : [],
+            functionKeys: functionKeys(module),
+            exports: module
+              ? Object.fromEntries(
+                  Object.entries(module).map(([key, value]) => [
+                    key,
+                    {
+                      type: typeof value,
+                      keys:
+                        value && typeof value === 'object'
+                          ? Object.keys(value).sort()
+                          : [],
+                      prototypeMethods:
+                        value &&
+                        (typeof value === 'object' ||
+                          typeof value === 'function')
+                          ? Object.getOwnPropertyNames(
+                              Object.getPrototypeOf(value) || {}
+                            )
+                              .filter(
+                                (name) =>
+                                  name !== 'constructor' &&
+                                  typeof (value as any)[name] === 'function'
+                              )
+                              .sort()
+                          : [],
+                    },
+                  ])
+                )
+              : {},
+          };
+        } catch (error) {
+          directModules[id] = {
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      }
+      try {
+        const ongoingModule =
+          scope.importNamespace?.('WAWebVoipOngoingCallCollection') ||
+          scope.require?.('WAWebVoipOngoingCallCollection');
+        const collection = ongoingModule?.WAWebVoipOngoingCallCollection;
+        const rawModels = collection?._models;
+        const models =
+          typeof collection?.getModelsArray === 'function'
+            ? collection.getModelsArray()
+            : rawModels instanceof Map
+            ? [...rawModels.values()]
+            : Array.isArray(rawModels)
+            ? rawModels
+            : rawModels && typeof rawModels === 'object'
+            ? Object.values(rawModels)
+            : [];
+        recentOngoingCalls = models.slice(-10).map((model: any) => ({
+          keys: Object.keys(model).sort(),
+          primitiveFields: Object.fromEntries(
+            Object.entries(model).filter(
+              ([, value]) =>
+                value == null ||
+                ['string', 'number', 'boolean'].includes(typeof value)
+            )
+          ),
+          id: String(model.id || model.callId || model.getCallId?.() || ''),
+          peerJid:
+            model.peerJid?.toString?.() ||
+            model.peerWid?.toString?.() ||
+            model.chatId?.toString?.() ||
+            '',
+        }));
+      } catch {
+        recentOngoingCalls = [];
+      }
+      try {
+        const initEventModule =
+          scope.importNamespace?.('WAWebVoipInitEventEmitter') ||
+          scope.require?.('WAWebVoipInitEventEmitter');
+        const emitter = initEventModule?.VoipInitEventEmitter;
+        voipInitState = {
+          initialized: emitter?.getIsVoipInited?.(),
+          error: emitter?.getDidVoipInitError?.(),
+          failureClass: emitter?.getVoipInitFailureClass?.(),
+        };
+      } catch (error) {
+        voipInitState = {
+          diagnosticError:
+            error instanceof Error ? error.message : String(error),
+        };
+      }
+    } catch {
+      // The diagnostic remains useful on legacy webpack builds.
+    }
+    try {
+      backend = await whatsapp?.requireVoipJsBackend?.();
+    } catch (error) {
+      backendError = error instanceof Error ? error.message : String(error);
+    }
+    try {
+      stack = await whatsapp?.getVoipStackInterface?.();
+    } catch (error) {
+      stackError = error instanceof Error ? error.message : String(error);
+    }
+    return {
+      crossOriginIsolated: scope.crossOriginIsolated,
+      sharedArrayBuffer: typeof scope.SharedArrayBuffer === 'function',
+      audioContext: typeof scope.AudioContext === 'function',
+      rtcPeerConnection: typeof scope.RTCPeerConnection === 'function',
+      mediaDevices: Boolean(scope.navigator?.mediaDevices),
+      callStore: Boolean(whatsapp?.CallStore),
+      recentCalls: whatsapp?.CallStore
+        ? whatsapp.CallStore.getModelsArray()
+            .slice(-10)
+            .map((call: any) => ({
+              id: String(call.id || ''),
+              peerJid: call.peerJid?.toString?.() || String(call.peerJid || ''),
+              offerTime: Number(call.offerTime || 0),
+              state: call.getState?.(),
+              outgoing: Boolean(call.outgoing),
+              wasEverConnected: Boolean(call.wasEverConnected),
+            }))
+        : [],
+      recentOngoingCalls,
+      voipInitState,
+      whatsappVoipKeys: whatsapp
+        ? Object.keys(whatsapp)
+            .filter((key) => /voip|call/i.test(key))
+            .sort()
+        : [],
+      matchingModuleIds,
+      directModules,
+      callingEnabled: whatsapp?.isCallingEnabled?.(),
+      unsupportedBrowser: whatsapp?.isUnsupportedBrowserForWebCalling?.(),
+      voipDownloadEnabled: whatsapp?.isVoipDownloadEnabled?.(),
+      backendError,
+      backendKeys: backend ? Object.keys(backend).sort() : [],
+      backendFunctionKeys: functionKeys(backend),
+      backendModuleFunctionKeys: backend
+        ? Object.fromEntries(
+            Object.entries(backend)
+              .filter(([, value]) => value && typeof value === 'object')
+              .map(([key, value]) => [key, functionKeys(value)])
+              .filter(([, keys]) => (keys as string[]).length)
+          )
+        : {},
+      stackError,
+      stackKeys: stack ? Object.keys(stack).sort() : [],
+      stackFunctionKeys: functionKeys(stack),
+    };
   });
 }
 
@@ -162,12 +451,98 @@ export async function acceptCall(
   return page.evaluate(
     async ({ callId }) => {
       const scope = globalThis as typeof globalThis & { WPP: any };
-      const call = callId
+      const nativeAnswerAvailable = [
+        ...document.querySelectorAll<HTMLElement>('button, [role="button"]'),
+      ].some((element) => {
+        const label = [
+          element.getAttribute('aria-label'),
+          element.getAttribute('title'),
+          element.textContent,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return (
+          /\b(atender|aceitar|answer|accept)\b/i.test(label) &&
+          element.getClientRects().length > 0
+        );
+      });
+      const call = nativeAnswerAvailable
+        ? undefined
+        : callId
         ? scope.WPP.whatsapp.CallStore.get(callId)
         : scope.WPP.whatsapp.CallStore.getModelsArray().find(
             (item: any) => item.getState?.() === 3 && !item.outgoing
           );
-      if (!call) return scope.WPP.call.accept(callId);
+      const waitForPeerConnection = async (timeoutMs = 8_000) =>
+        new Promise<boolean>((resolve) => {
+          const deadline = Date.now() + timeoutMs;
+          const inspect = () => {
+            const peerConnections = [
+              ...((scope as any).__wppconnectCallPeerConnections || []),
+            ];
+            const connected = peerConnections.some(
+              (connection: RTCPeerConnection) =>
+                connection.connectionState === 'connected' ||
+                connection.iceConnectionState === 'connected' ||
+                connection.iceConnectionState === 'completed'
+            );
+            if (connected) resolve(true);
+            else if (Date.now() >= deadline) resolve(false);
+            else setTimeout(inspect, 100);
+          };
+          inspect();
+        });
+
+      if (!call) {
+        const elements = [
+          ...document.querySelectorAll<HTMLElement>('button, [role="button"]'),
+        ];
+        const labelOf = (element: HTMLElement) =>
+          [
+            element.getAttribute('aria-label'),
+            element.getAttribute('title'),
+            element.getAttribute('data-testid'),
+            element.textContent,
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+        const answerPattern = /\b(atender|aceitar|answer|accept)\b/i;
+        const rejectPattern = /\b(rejeitar|recusar|decline|reject|ignore)\b/i;
+        const answerButton = elements.find((element) => {
+          const label = labelOf(element);
+          const style = getComputedStyle(element);
+          return (
+            answerPattern.test(label) &&
+            !rejectPattern.test(label) &&
+            style.display !== 'none' &&
+            style.visibility !== 'hidden' &&
+            element.getClientRects().length > 0
+          );
+        });
+        if (!answerButton) {
+          const visibleLabels = elements
+            .filter((element) => element.getClientRects().length > 0)
+            .map(labelOf)
+            .filter(Boolean)
+            .slice(0, 100);
+          throw new Error(
+            `Native WhatsApp answer button not found; visible controls=${JSON.stringify(
+              visibleLabels
+            )}`
+          );
+        }
+        answerButton.click();
+        if (!(await waitForPeerConnection())) {
+          throw new Error(
+            `Native WhatsApp answer button was clicked but WebRTC did not connect (control=${labelOf(
+              answerButton
+            )})`
+          );
+        }
+        return true;
+      }
 
       const state = call.getState?.();
       const peerJid = call.peerJid;
@@ -192,13 +567,26 @@ export async function acceptCall(
         peerJid.toString = () => phoneNumber;
       }
       try {
-        const acceptance = scope.WPP.call.accept(callId || String(call.id));
-        return await Promise.race([
-          acceptance,
-          new Promise<boolean>((resolve) =>
-            setTimeout(() => resolve(true), 3_000)
+        await Promise.race([
+          scope.WPP.call.accept(callId || String(call.id)),
+          new Promise<void>((_, reject) =>
+            setTimeout(
+              () => reject(new Error('Timed out sending the call acceptance')),
+              3_000
+            )
           ),
         ]);
+
+        const connected =
+          call.wasEverConnected === true || (await waitForPeerConnection());
+        if (!connected) {
+          throw new Error(
+            `WhatsApp did not confirm call connection (state=${String(
+              call.getState?.()
+            )}, wasEverConnected=${String(call.wasEverConnected)})`
+          );
+        }
+        return true;
       } finally {
         call.getState = originalGetState;
         if (isLid && originalIsGroupCall) {

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -70,11 +70,9 @@ export async function acceptCall(
   );
 }
 
-export async function endCall(page: Page, callId?: string): Promise<boolean> {
-  return page.evaluate(
-    ({ callId }) =>
-      (globalThis as typeof globalThis & { WPP: any }).WPP.call.end(callId),
-    { callId }
+export async function endCall(page: Page): Promise<boolean> {
+  return page.evaluate(() =>
+    (globalThis as typeof globalThis & { WPP: any }).WPP.call.end()
   );
 }
 
@@ -103,7 +101,7 @@ export async function offerCall(
  */
 export async function installIncomingAudioCapture(
   page: Page,
-  onChunk: (chunk: IncomingCallAudioChunk) => void | Promise<void>,
+  onChunk?: (chunk: IncomingCallAudioChunk) => void | Promise<void>,
   options: IncomingAudioCaptureOptions = {}
 ): Promise<void> {
   let handlers = incomingAudioHandlers.get(page);
@@ -128,7 +126,7 @@ export async function installIncomingAudioCapture(
       }
     }
   }
-  handlers.add(onChunk);
+  if (onChunk) handlers.add(onChunk);
 
   const timesliceMs = Math.max(100, options.timesliceMs ?? 250);
   await page.evaluate(

--- a/src/util/callUtil.ts
+++ b/src/util/callUtil.ts
@@ -460,8 +460,15 @@ export async function getCallInterfaceDiagnostics(
             ),
             captureSampleRate:
               scope.__wppconnectVoipScriptBridge.captureSampleRate,
-            outgoingQueued:
-              scope.__wppconnectVoipScriptBridge.outgoingQueue?.length || 0,
+            outgoingQueued: Math.max(
+              0,
+              (scope.__wppconnectVoipScriptBridge.outgoingQueue?.length || 0) -
+                (scope.__wppconnectVoipScriptBridge.outgoingReadOffset || 0)
+            ),
+            outgoingUnderruns:
+              scope.__wppconnectVoipScriptBridge.outgoingUnderruns || 0,
+            outgoingOverflowSamples:
+              scope.__wppconnectVoipScriptBridge.outgoingOverflowSamples || 0,
             playbackQueued:
               scope.__wppconnectVoipScriptBridge.playbackSamples?.length || 0,
           }
@@ -762,7 +769,11 @@ export async function installIncomingAudioCapture(
         captureProcessor: null,
         captureSampleRate: 48_000,
         outgoingQueue: [],
+        outgoingReadOffset: 0,
         outgoingStarted: false,
+        outgoingUnderflowing: false,
+        outgoingUnderruns: 0,
+        outgoingOverflowSamples: 0,
         lastOutgoingSample: 0,
         playbackSamples: [],
       };
@@ -817,9 +828,11 @@ export async function installIncomingAudioCapture(
             const prebufferSamples = Math.round(
               bridge.captureSampleRate * 0.12
             );
+            const availableSamples =
+              bridge.outgoingQueue.length - bridge.outgoingReadOffset;
             if (
               !bridge.outgoingStarted &&
-              bridge.outgoingQueue.length >= prebufferSamples
+              availableSamples >= prebufferSamples
             ) {
               bridge.outgoingStarted = true;
             }
@@ -828,8 +841,9 @@ export async function installIncomingAudioCapture(
                 input[index] = 0;
                 continue;
               }
-              const queued = bridge.outgoingQueue.shift();
+              const queued = bridge.outgoingQueue[bridge.outgoingReadOffset++];
               if (queued == null) {
+                bridge.outgoingReadOffset = bridge.outgoingQueue.length;
                 const remaining = input.length - index;
                 for (let fade = index; fade < input.length; fade++) {
                   input[fade] =
@@ -837,11 +851,22 @@ export async function installIncomingAudioCapture(
                     ((input.length - fade - 1) / Math.max(1, remaining));
                 }
                 bridge.lastOutgoingSample = 0;
-                bridge.outgoingStarted = false;
+                if (!bridge.outgoingUnderflowing) {
+                  bridge.outgoingUnderflowing = true;
+                  bridge.outgoingUnderruns++;
+                }
                 break;
               }
+              bridge.outgoingUnderflowing = false;
               input[index] = queued;
               bridge.lastOutgoingSample = queued;
+            }
+            if (
+              bridge.outgoingReadOffset > 48_000 &&
+              bridge.outgoingReadOffset * 2 > bridge.outgoingQueue.length
+            ) {
+              bridge.outgoingQueue.splice(0, bridge.outgoingReadOffset);
+              bridge.outgoingReadOffset = 0;
             }
             original?.call(processor, event);
           };
@@ -1094,11 +1119,20 @@ export async function pushOutgoingPcm16(
           const sample = input[left] * (1 - fraction) + input[right] * fraction;
           voipBridge.outgoingQueue.push(sample / 32768);
         }
-        if (voipBridge.outgoingQueue.length > outputRate * 5) {
-          voipBridge.outgoingQueue.splice(
-            0,
-            voipBridge.outgoingQueue.length - outputRate * 5
-          );
+        const queuedSamples =
+          voipBridge.outgoingQueue.length - voipBridge.outgoingReadOffset;
+        const maxBufferedSamples = outputRate * 180;
+        if (queuedSamples > maxBufferedSamples) {
+          const excess = queuedSamples - maxBufferedSamples;
+          voipBridge.outgoingReadOffset += excess;
+          voipBridge.outgoingOverflowSamples += excess;
+        }
+        if (
+          voipBridge.outgoingReadOffset > outputRate &&
+          voipBridge.outgoingReadOffset * 2 > voipBridge.outgoingQueue.length
+        ) {
+          voipBridge.outgoingQueue.splice(0, voipBridge.outgoingReadOffset);
+          voipBridge.outgoingReadOffset = 0;
         }
         return true;
       }

--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -57,6 +57,7 @@ export default class CreateSessionUtil {
 
       if (req.serverOptions.customUserDataDir) {
         req.serverOptions.createOptions.puppeteerOptions = {
+          ...req.serverOptions.createOptions.puppeteerOptions,
           userDataDir: req.serverOptions.customUserDataDir + session,
         };
       }

--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -18,6 +18,7 @@ import { Request } from 'express';
 
 import { download } from '../controller/sessionController';
 import { WhatsAppServer } from '../types/WhatsAppServer';
+import { deactivateCallMedia } from './callMediaUtil';
 import chatWootClient from './chatWootClient';
 import { autoDownload, callWebHook, startHelper } from './functions';
 import { clientsArray, eventEmitter } from './sessionUtil';
@@ -117,6 +118,7 @@ export default class CreateSessionUtil {
                   client.status = 'CLOSED';
                   client.qrcode = null;
                   client.close();
+                  deactivateCallMedia(session);
                   clientsArray[session] = undefined;
                 }
                 callWebHook(client, req, 'status-find', {

--- a/src/util/sessionUtil.ts
+++ b/src/util/sessionUtil.ts
@@ -16,6 +16,8 @@
 import { Whatsapp } from '@wppconnect-team/wppconnect';
 import { EventEmitter } from 'events';
 
+import { deactivateCallMedia } from './callMediaUtil';
+
 export const chromiumArgs = [
   '--disable-web-security', // Disables web security
   '--no-sandbox', // Disables sandbox
@@ -44,6 +46,7 @@ export const sessions = [];
 export const eventEmitter = new EventEmitter();
 
 export function deleteSessionOnArray(session: string): void {
+  deactivateCallMedia(session);
   const newArray = clientsArray;
   delete clientsArray[session];
   clientsArray = newArray;

--- a/src/util/sessionUtil.ts
+++ b/src/util/sessionUtil.ts
@@ -33,7 +33,10 @@ export const chromiumArgs = [
   '--disable-translate', // Disables translation
   '--hide-scrollbars', // Hides scrollbars
   '--metrics-recording-only', // Records metrics only
-  '--mute-audio', // Mutes audio
+  '--use-fake-ui-for-media-stream',
+  '--use-fake-device-for-media-stream',
+  '--enable-features=SharedArrayBuffer', // Required by the WhatsApp VoIP backend
+  '--use-file-for-fake-audio-capture=/usr/src/wpp-server/silence.wav',
   '--no-first-run', // Skips first run
   '--safebrowsing-disable-auto-update', // Disables Safe Browsing auto-update
   '--ignore-certificate-errors', // Ignores certificate errors

--- a/yarn.lock
+++ b/yarn.lock
@@ -5716,6 +5716,7 @@ __metadata:
     sharp: "npm:^0.34.5"
     shx: "npm:^0.4.0"
     socket.io: "npm:^4.8.3"
+    socket.io-client: "npm:^4.8.3"
     swagger-autogen: "npm:^2.23.7"
     swagger-ui-dist: "npm:^5.32.1"
     swagger-ui-express: "npm:^5.0.1"
@@ -8258,6 +8259,19 @@ __metadata:
   dependencies:
     once: "npm:^1.4.0"
   checksum: 10c0/b0701c92a10b89afb1cb45bf54a5292c6f008d744eb4382fa559d54775ff31617d1d7bc3ef617575f552e24fad2c7c1a1835948c66b3f3a4be0a6c1f35c883d8
+  languageName: node
+  linkType: hard
+
+"engine.io-client@npm:~6.6.1":
+  version: 6.6.6
+  resolution: "engine.io-client@npm:6.6.6"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.4.1"
+    engine.io-parser: "npm:~5.2.1"
+    ws: "npm:~8.21.0"
+    xmlhttprequest-ssl: "npm:~2.1.1"
+  checksum: 10c0/805995b57b2656f52322004b4d767851b517618b1fcecabf5968c55ce6864c692e594fe3a6ae9284504aa087a5a872b0ea1b76b876dcf4cf866907bd61e9e1dd
   languageName: node
   linkType: hard
 
@@ -14809,6 +14823,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"socket.io-client@npm:^4.8.3":
+  version: 4.8.3
+  resolution: "socket.io-client@npm:4.8.3"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.4.1"
+    engine.io-client: "npm:~6.6.1"
+    socket.io-parser: "npm:~4.2.4"
+  checksum: 10c0/76c0d86de0b636d0bf5011cf3425212c900f43dac632db6eb493816920cd035af7ddd92fea9a106b45eb347405953c0414eb3a5d465b180215e46fc8b61420b3
+  languageName: node
+  linkType: hard
+
 "socket.io-parser@npm:~4.2.4":
   version: 4.2.4
   resolution: "socket.io-parser@npm:4.2.4"
@@ -16414,7 +16440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.20.0, ws@npm:^8.21.0":
+"ws@npm:^8.20.0, ws@npm:^8.21.0, ws@npm:~8.21.0":
   version: 8.21.1
   resolution: "ws@npm:8.21.1"
   peerDependencies:
@@ -16450,6 +16476,13 @@ __metadata:
   dependencies:
     is-wsl: "npm:^3.1.0"
   checksum: 10c0/44318f3585eb97be994fc21a20ddab2649feaf1fbe893f1f866d936eea3d5f8c743bec6dc02e49fbdd3c0e69e9b36f449d90a0b165a4f47dd089747af4cf2377
+  languageName: node
+  linkType: hard
+
+"xmlhttprequest-ssl@npm:~2.1.1":
+  version: 2.1.2
+  resolution: "xmlhttprequest-ssl@npm:2.1.2"
+  checksum: 10c0/70d60869323e823f473a238f78fd108437edbc3690ecd5859c39c83217080090a18899b272e515769c0d1f518cc64cbed6b6995b23fdd7ba13b297d530b6e631
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5735,9 +5735,9 @@ __metadata:
   linkType: soft
 
 "@wppconnect/wa-js@npm:^4.4.3":
-  version: 4.4.3
-  resolution: "@wppconnect/wa-js@npm:4.4.3"
-  checksum: 10c0/5784d2ef045a0c663522a77d22c024bbd4ed1920f497b1100cd36457eb821ed783f09808bebd4ae64ab6b911547bd1819c527fb8161594c8c6bc0ccbfa500fc2
+  version: 4.5.0
+  resolution: "@wppconnect/wa-js@npm:4.5.0"
+  checksum: 10c0/024e54250aadd1abd11e1dff4116766959592c78f8c9ea4cb9c7a80b09fd097378d7c5a1b8611624234696e6ff030180aa9e668829905066a8621c6361fefc7f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed

- adds call signalling endpoints for offer, accept, end, and call interface activation
- captures incoming WebRTC audio as signed PCM16 using Web Audio
- accepts outbound signed PCM16 and replaces the active WebRTC audio sender
- uses MediaStreamTrackGenerator with paced 20 ms frames, with a Web Audio fallback
- adds a dedicated Socket.IO media namespace with short-lived, single-use tickets
- isolates every socket and media event by both session and callId
- invalidates tickets and disconnects the media room when a call or session ends
- installs opt-in WebRTC instrumentation before calls are created
- includes a runnable live-call smoke client
- documents protocol, connection sequence, security constraints, and limitations

## Why

Recent WA-JS builds expose WhatsApp VoIP signalling, but call.offer only sends an offer without audio/video. This contribution establishes the server API and an experimental browser media bridge for full-duplex audio.

## Validation

- Node 22.22.2 (matching Dockerfile)
- ESLint passed
- 10 Jest suites / 32 tests passed
- real headless Chromium WebRTC test proves incoming PCM16 capture, non-silent outbound PCM16 frame generation, sender-track replacement, and RTP delivery to the remote peer
- real Socket.IO integration test proves invalid/reused ticket rejection, call-room isolation, and selective disconnect
- smoke client passes syntax validation and documents the live procedure
- TypeScript and Babel build passed

## Important limitation

The browser and transport mechanisms are validated end to end with local WebRTC peers, but they have not yet been exercised against a live WhatsApp call and the exact pinned WhatsApp Web build. The PR remains a draft until that external validation is complete.