### PR TITLE
ci: set explicit workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: 'patch'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-lock.yml
+++ b/.github/workflows/update-lock.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: write
+
 jobs:
   update-lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- declare least-privilege `GITHUB_TOKEN` permissions for every flagged workflow
- preserve write access only where the workflow publishes or commits generated files
- keep read-only jobs restricted to repository contents

## Validation
- all modified workflows parse as valid YAML
- `actionlint` v1.7.7 passes
- `git diff --check` passes

## Security
This addresses the open `actions/missing-workflow-permissions` code-scanning findings. AI-assisted changes were reviewed and validated before submission.