### PR TITLE
fix(docker): cancel obsolete image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE_NAME: wppconnect/wppconnect-server
 


### PR DESCRIPTION
Prevents an older main build from overwriting the moving Docker tag after a newer release commit has started. Builds for tags and pull requests keep independent concurrency groups. Validated with actionlint.