### PR TITLE
fix(messages): forward to normalized contact list

### DIFF
--- a/src/controller/deviceController.ts
+++ b/src/controller/deviceController.ts
@@ -1006,15 +1006,14 @@ export async function forwardMessages(req: Request, res: Response) {
   const { phone, messageId, isGroup = false } = req.body;
 
   try {
+    const contacts = contactToArray(phone, isGroup);
     let response;
 
-    if (!isGroup) {
-      response = await req.client.forwardMessagesV2(`${phone[0]}`, messageId);
-    } else {
-      response = await req.client.forwardMessagesV2(`${phone[0]}`, messageId);
+    for (const contact of contacts) {
+      response = await req.client.forwardMessagesV2(contact, messageId);
     }
 
-    res.status(201).json({ status: 'success', response: response });
+    res.status(201).json({ status: 'success', response });
   } catch (e) {
     req.logger.error(e);
     res

--- a/src/tests/controller/deviceController.test.ts
+++ b/src/tests/controller/deviceController.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { forwardMessages } from '../../controller/deviceController';
+
+jest.mock('../../util/functions', () => ({
+  contactToArray: jest.fn(),
+  unlinkAsync: jest.fn(),
+}));
+jest.mock('../../util/sessionUtil', () => ({ clientsArray: [] }));
+
+const { contactToArray: mockContactToArray } = jest.requireMock(
+  '../../util/functions'
+) as { contactToArray: jest.Mock };
+
+describe('forwardMessages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createResponse() {
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    res.json.mockReturnValue(res);
+    return res;
+  }
+
+  it('normalizes and forwards every requested contact', async () => {
+    mockContactToArray.mockReturnValue([
+      '5511999999999@c.us',
+      '5521888888888@c.us',
+    ]);
+    const forwardMessagesV2 = jest
+      .fn()
+      .mockResolvedValueOnce('first')
+      .mockResolvedValueOnce('second');
+    const req = {
+      body: {
+        phone: '5511999999999,5521888888888',
+        messageId: 'message-id',
+      },
+      client: { forwardMessagesV2 },
+      logger: { error: jest.fn() },
+    };
+    const res = createResponse();
+
+    await forwardMessages(req as any, res as any);
+
+    expect(mockContactToArray).toHaveBeenCalledWith(
+      '5511999999999,5521888888888',
+      false
+    );
+    expect(forwardMessagesV2).toHaveBeenNthCalledWith(
+      1,
+      '5511999999999@c.us',
+      'message-id'
+    );
+    expect(forwardMessagesV2).toHaveBeenNthCalledWith(
+      2,
+      '5521888888888@c.us',
+      'message-id'
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      status: 'success',
+      response: 'second',
+    });
+  });
+
+  it('keeps a complete group identifier instead of its first character', async () => {
+    mockContactToArray.mockReturnValue(['120363000000000000@g.us']);
+    const forwardMessagesV2 = jest.fn().mockResolvedValue('forwarded');
+    const req = {
+      body: {
+        phone: '120363000000000000@g.us',
+        messageId: 'message-id',
+        isGroup: true,
+      },
+      client: { forwardMessagesV2 },
+      logger: { error: jest.fn() },
+    };
+    const res = createResponse();
+
+    await forwardMessages(req as any, res as any);
+
+    expect(forwardMessagesV2).toHaveBeenCalledWith(
+      '120363000000000000@g.us',
+      'message-id'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- normalize the requested recipients with the existing contact helper
- forward the message to every normalized contact instead of only the first character
- preserve complete group IDs
- add regression coverage for multiple contacts and groups

This extracts the forwarding fix from #2513 so it can be reviewed and released independently from the status-stories feature.

Fixes #2414

## Validation
- yarn jest src/tests/controller/deviceController.test.ts --runInBand
- yarn eslint src/controller/deviceController.ts src/tests/controller/deviceController.test.ts
- yarn build
- git diff --check