### PR TITLE
Fix/chromium singleton lock cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ RUN yarn build
 FROM build AS runtime
 WORKDIR /usr/src/wpp-server/
 
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 # Install runtime dependencies (chromium and vips libraries)
 RUN apk add --no-cache \
     chromium \
@@ -46,4 +49,4 @@ RUN apk add --no-cache \
     fftw
 
 EXPOSE 21465
-ENTRYPOINT ["node", "dist/server.js"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 services:
   wppconnect:
     container_name: wpp-server
-    image: wppconnect/wppconnect-server:${WPP_SERVER_TAG:-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: wppconnect/wppconnect-server:local
     restart: unless-stopped
     environment:
       PORT: "21465"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,7 @@
 services:
   wppconnect:
     container_name: wpp-server
-    build:
-      context: .
-      dockerfile: Dockerfile
-    image: wppconnect/wppconnect-server:local
+    image: wppconnect/wppconnect-server:${WPP_SERVER_TAG:-latest}
     restart: unless-stopped
     environment:
       PORT: "21465"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+USER_DATA_DIR="${CUSTOM_USER_DATA_DIR:-/usr/src/wpp-server/userDataDir}"
+
+echo "Cleaning stale Chromium lock files from ${USER_DATA_DIR}..."
+
+if [ -d "$USER_DATA_DIR" ]; then
+  find "$USER_DATA_DIR" -name "Singleton*" -print -exec rm -rf {} +
+fi
+
+echo "🚀 Starting WPPConnect..."
+
+exec node dist/server.js


### PR DESCRIPTION
## Description

This is a new, focused PR based on the feedback from my previous Chromium `SingletonLock` PR.

Compared to the previous PR, I removed the unrelated and accidental changes and kept only what is necessary to address the Chromium lock issue.

### What changed

- Removed unrelated Docker Compose changes.
- Changed the cleanup path from `/data/userDataDir` to the actual WPPConnect user data directory.
- The entrypoint now uses `CUSTOM_USER_DATA_DIR` when provided, with `/usr/src/wpp-server/userDataDir` as the default.
- Removed Portuguese comments/messages and kept the implementation in English.
- Removed silent error suppression from the cleanup so failures remain visible in the logs.

The fix now focuses only on removing stale Chromium `Singleton*` files before WPPConnect starts.

These stale lock files can remain after a container restart and cause Chromium to fail with:

`The profile appears to be in use by another Chromium process`

This PR is intentionally smaller and scoped specifically to that issue, as suggested in the previous review.