### PR TITLE
fix: allow restoring catalog product visibility

### DIFF
--- a/src/controller/catalogController.ts
+++ b/src/controller/catalogController.ts
@@ -667,10 +667,11 @@ export async function setProductVisibility(req: Request, res: Response) {
     }
    */
   const { id, value } = req.body;
-  if (!id || !value)
-    res.status(401).send({
+  if (!id || typeof value !== 'boolean') {
+    return res.status(400).send({
       message: 'product id or value (false, true) was not informed',
     });
+  }
 
   try {
     const result = await getClient(req).setProductVisibility(id, value);

--- a/src/tests/controller/catalogController.test.ts
+++ b/src/tests/controller/catalogController.test.ts
@@ -22,14 +22,20 @@ jest.mock('../../core/provider/useProvider', () => ({ getClient: jest.fn() }));
 
 describe('catalog visibility controller', () => {
   const response = () => {
-    const res = { status: jest.fn(), json: jest.fn(), send: jest.fn() } as unknown as Response;
+    const res = {
+      status: jest.fn(),
+      json: jest.fn(),
+      send: jest.fn(),
+    } as unknown as Response;
     (res.status as jest.Mock).mockReturnValue(res);
     return res;
   };
 
   it('accepts false to make an archived product visible again', async () => {
     const setVisibility = jest.fn().mockResolvedValue({ id: 'product-1' });
-    (getClient as jest.Mock).mockReturnValue({ setProductVisibility: setVisibility });
+    (getClient as jest.Mock).mockReturnValue({
+      setProductVisibility: setVisibility,
+    });
     const req = { body: { id: 'product-1', value: false } } as Request;
     const res = response();
 

--- a/src/tests/controller/catalogController.test.ts
+++ b/src/tests/controller/catalogController.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { Request, Response } from 'express';
+
+import { setProductVisibility } from '../../controller/catalogController';
+import { getClient } from '../../core/provider/useProvider';
+
+jest.mock('../../core/provider/useProvider', () => ({ getClient: jest.fn() }));
+
+describe('catalog visibility controller', () => {
+  const response = () => {
+    const res = { status: jest.fn(), json: jest.fn(), send: jest.fn() } as unknown as Response;
+    (res.status as jest.Mock).mockReturnValue(res);
+    return res;
+  };
+
+  it('accepts false to make an archived product visible again', async () => {
+    const setVisibility = jest.fn().mockResolvedValue({ id: 'product-1' });
+    (getClient as jest.Mock).mockReturnValue({ setProductVisibility: setVisibility });
+    const req = { body: { id: 'product-1', value: false } } as Request;
+    const res = response();
+
+    await setProductVisibility(req, res);
+
+    expect(setVisibility).toHaveBeenCalledWith('product-1', false);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.send).not.toHaveBeenCalled();
+  });
+
+  it('stops before the provider when visibility is missing', async () => {
+    const provider = { setProductVisibility: jest.fn() };
+    (getClient as jest.Mock).mockReturnValue(provider);
+    const req = { body: { id: 'product-1' } } as Request;
+    const res = response();
+
+    await setProductVisibility(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(provider.setProductVisibility).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- accept an explicit false visibility value so archived products can be shown again
- return immediately with 400 when the boolean is missing
- cover both paths in the catalog controller

## Validation
- 2 focused Jest tests passed
- TypeScript build passed
- local dependency link reported the existing Puppeteer postinstall failure, but the immutable dependency graph was still sufficient for both checks