### PR TITLE
feat: add optional Media API adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ the same defaults as `src/config.ts`: `PORT`, `HOST`, `SECRET_KEY`,
 `MONGODB_DATABASE`, `MONGODB_COLLECTION`, `MONGODB_USER`, `MONGODB_PASSWORD`,
 `MONGODB_HOST`, `MONGODB_PORT`, and `MONGO_URL_REMOTE`.
 
+The optional managed Media API adapter uses `MEDIA_API_URL`, `MEDIA_API_KEY`,
+and `MEDIA_API_TIMEOUT_MS` (default `30000`). When configured, authenticated
+server clients can create conversion or transcription jobs through
+`POST /api/:session/media/conversions` and
+`POST /api/:session/media/transcriptions`, then poll
+`GET /api/:session/media/jobs/:jobId`. Creation accepts the same JSON URL or
+multipart `file` contract as the compatible Media API and forwards the required
+`Idempotency-Key` without exposing the upstream API key.
+
 Docker image publishing is handled by GitHub Actions:
 
 - pushes to `main` publish the moving `main` tag and a `sha-*` tag;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       WEBHOOK_URL: "${WEBHOOK_URL:-}"
       TOKEN_STORE_TYPE: "${TOKEN_STORE_TYPE:-file}"
       CUSTOM_USER_DATA_DIR: "/usr/src/wpp-server/userDataDir/"
+      MEDIA_API_URL: "${MEDIA_API_URL:-}"
+      MEDIA_API_KEY: "${MEDIA_API_KEY:-}"
+      MEDIA_API_TIMEOUT_MS: "${MEDIA_API_TIMEOUT_MS:-30000}"
     volumes:
       - wppconnect_tokens:/usr/src/wpp-server/tokens
       - wppconnect_user_data:/usr/src/wpp-server/userDataDir

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,6 +98,11 @@ export default {
     enable: false,
     prefix: 'tagone-',
   },
+  mediaApi: {
+    baseUrl: env.MEDIA_API_URL || null,
+    apiKey: env.MEDIA_API_KEY || null,
+    timeoutMs: envNumber('MEDIA_API_TIMEOUT_MS', 30000),
+  },
   db: {
     mongodbDatabase: env.MONGODB_DATABASE || 'tokens',
     mongodbCollection: env.MONGODB_COLLECTION || '',

--- a/src/controller/mediaController.ts
+++ b/src/controller/mediaController.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Request, Response } from 'express';
+import { readFile } from 'fs/promises';
+
+import {
+  MediaApiAdapterError,
+  MediaApiClient,
+  MediaApiResponse,
+  MediaJobInput,
+  MediaUpload,
+} from '../core/media/MediaApiClient';
+import { unlinkAsync } from '../util/functions';
+
+function idempotencyKey(req: Request): string {
+  const value = req.headers['idempotency-key'];
+  return Array.isArray(value) ? value[0] || '' : value || '';
+}
+
+function input(req: Request): MediaJobInput {
+  const source = req.body || {};
+  return {
+    ...(typeof source.sourceUrl === 'string'
+      ? { sourceUrl: source.sourceUrl }
+      : {}),
+    ...(typeof source.filename === 'string'
+      ? { filename: source.filename }
+      : {}),
+    ...(typeof source.mimeType === 'string'
+      ? { mimeType: source.mimeType }
+      : {}),
+    ...(typeof source.language === 'string'
+      ? { language: source.language }
+      : {}),
+    ...(typeof source.webhookUrl === 'string'
+      ? { webhookUrl: source.webhookUrl }
+      : {}),
+  };
+}
+
+async function upload(req: Request): Promise<MediaUpload | undefined> {
+  if (!req.file) return undefined;
+  return {
+    bytes: new Uint8Array(await readFile(req.file.path)),
+    filename: req.file.originalname,
+    mimeType: req.file.mimetype,
+  };
+}
+
+function client(req: Request): MediaApiClient {
+  return new MediaApiClient(req.serverOptions.mediaApi);
+}
+
+function reply(res: Response, result: MediaApiResponse) {
+  return res.status(result.status).json(result.body);
+}
+
+function replyError(req: Request, res: Response, error: unknown) {
+  if (error instanceof MediaApiAdapterError) {
+    return res.status(error.httpStatus).json({
+      status: 'error',
+      message: error.message,
+    });
+  }
+  req.logger.error(error);
+  return res.status(500).json({
+    status: 'error',
+    message: 'Unexpected Media API adapter error',
+  });
+}
+
+async function createJob(
+  req: Request,
+  res: Response,
+  kind: 'conversion' | 'transcription'
+) {
+  try {
+    const mediaClient = client(req);
+    const mediaUpload = await upload(req);
+    const result =
+      kind === 'conversion'
+        ? await mediaClient.createConversion(
+            input(req),
+            idempotencyKey(req),
+            mediaUpload
+          )
+        : await mediaClient.createTranscription(
+            input(req),
+            idempotencyKey(req),
+            mediaUpload
+          );
+    return reply(res, result);
+  } catch (error) {
+    return replyError(req, res, error);
+  } finally {
+    if (req.file?.path) await unlinkAsync(req.file.path).catch(() => undefined);
+  }
+}
+
+export function createConversion(req: Request, res: Response) {
+  return createJob(req, res, 'conversion');
+}
+
+export function createTranscription(req: Request, res: Response) {
+  return createJob(req, res, 'transcription');
+}
+
+export async function getJob(req: Request, res: Response) {
+  try {
+    return reply(res, await client(req).getJob(req.params.jobId));
+  } catch (error) {
+    return replyError(req, res, error);
+  }
+}

--- a/src/core/media/MediaApiClient.ts
+++ b/src/core/media/MediaApiClient.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type MediaApiSettings = {
+  baseUrl: string | null;
+  apiKey: string | null;
+  timeoutMs: number;
+};
+
+export type MediaJobInput = {
+  sourceUrl?: string;
+  filename?: string;
+  mimeType?: string;
+  language?: string;
+  webhookUrl?: string;
+};
+
+export type MediaUpload = {
+  bytes: Uint8Array;
+  filename: string;
+  mimeType?: string;
+};
+
+export type MediaApiResponse = {
+  status: number;
+  body: unknown;
+};
+
+export class MediaApiAdapterError extends Error {
+  constructor(message: string, public readonly httpStatus: number) {
+    super(message);
+    this.name = 'MediaApiAdapterError';
+  }
+}
+
+function normalizedBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new MediaApiAdapterError('MEDIA_API_URL is invalid', 503);
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new MediaApiAdapterError('MEDIA_API_URL must use HTTP or HTTPS', 503);
+  }
+  return url.toString().replace(/\/$/, '');
+}
+
+async function responseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+}
+
+export class MediaApiClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly timeoutMs: number;
+
+  constructor(
+    settings: MediaApiSettings,
+    private readonly fetcher: typeof fetch = fetch
+  ) {
+    if (!settings.baseUrl || !settings.apiKey) {
+      throw new MediaApiAdapterError(
+        'Media API is not configured. Set MEDIA_API_URL and MEDIA_API_KEY.',
+        503
+      );
+    }
+    this.baseUrl = normalizedBaseUrl(settings.baseUrl);
+    this.apiKey = settings.apiKey;
+    this.timeoutMs =
+      Number.isFinite(settings.timeoutMs) && settings.timeoutMs > 0
+        ? settings.timeoutMs
+        : 30000;
+  }
+
+  createConversion(
+    input: MediaJobInput,
+    idempotencyKey: string,
+    upload?: MediaUpload
+  ): Promise<MediaApiResponse> {
+    return this.createJob(
+      '/v1/audio/conversions',
+      input,
+      idempotencyKey,
+      upload
+    );
+  }
+
+  createTranscription(
+    input: MediaJobInput,
+    idempotencyKey: string,
+    upload?: MediaUpload
+  ): Promise<MediaApiResponse> {
+    return this.createJob(
+      '/v1/audio/transcriptions',
+      input,
+      idempotencyKey,
+      upload
+    );
+  }
+
+  getJob(jobId: string): Promise<MediaApiResponse> {
+    return this.request(`/v1/jobs/${encodeURIComponent(jobId)}`, {
+      method: 'GET',
+    });
+  }
+
+  private createJob(
+    path: string,
+    input: MediaJobInput,
+    idempotencyKey: string,
+    upload?: MediaUpload
+  ): Promise<MediaApiResponse> {
+    const headers = new Headers({ 'idempotency-key': idempotencyKey });
+    let body: BodyInit;
+    if (upload) {
+      const form = new FormData();
+      const bytes = new ArrayBuffer(upload.bytes.byteLength);
+      new Uint8Array(bytes).set(upload.bytes);
+      form.append(
+        'file',
+        new Blob([bytes], {
+          type: upload.mimeType || 'application/octet-stream',
+        }),
+        upload.filename
+      );
+      if (input.language) form.append('language', input.language);
+      if (input.webhookUrl) form.append('webhookUrl', input.webhookUrl);
+      body = form;
+    } else {
+      headers.set('content-type', 'application/json');
+      body = JSON.stringify(input);
+    }
+    return this.request(path, { method: 'POST', headers, body });
+  }
+
+  private async request(
+    path: string,
+    init: RequestInit
+  ): Promise<MediaApiResponse> {
+    const headers = new Headers(init.headers);
+    headers.set('authorization', `Bearer ${this.apiKey}`);
+    try {
+      const response = await this.fetcher(`${this.baseUrl}${path}`, {
+        ...init,
+        headers,
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+      return { status: response.status, body: await responseBody(response) };
+    } catch (error) {
+      if (error instanceof Error && error.name === 'TimeoutError') {
+        throw new MediaApiAdapterError('Media API request timed out', 504);
+      }
+      throw new MediaApiAdapterError('Media API is unavailable', 502);
+    }
+  }
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -25,6 +25,7 @@ import * as DeviceController from '../controller/deviceController';
 import { encryptSession } from '../controller/encryptController';
 import * as GroupController from '../controller/groupController';
 import * as LabelsController from '../controller/labelsController';
+import * as MediaController from '../controller/mediaController';
 import * as MessageController from '../controller/messageController';
 import * as MiscController from '../controller/miscController';
 import * as NewsletterController from '../controller/newsletterController';
@@ -173,6 +174,26 @@ routes.post(
   verifyToken,
   statusConnection,
   SessionController.downloadMediaByMessage
+);
+
+// Optional managed Media API adapter. These routes use the WPPConnect Server
+// session token for ingress and a separately configured Media API key upstream.
+routes.post(
+  '/api/:session/media/conversions',
+  verifyToken,
+  upload.single('file'),
+  MediaController.createConversion
+);
+routes.post(
+  '/api/:session/media/transcriptions',
+  verifyToken,
+  upload.single('file'),
+  MediaController.createTranscription
+);
+routes.get(
+  '/api/:session/media/jobs/:jobId',
+  verifyToken,
+  MediaController.getJob
 );
 
 // Messages

--- a/src/tests/controller/mediaController.test.ts
+++ b/src/tests/controller/mediaController.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Request, Response } from 'express';
+
+import { createConversion, getJob } from '../../controller/mediaController';
+
+function response() {
+  const res = {
+    status: jest.fn(),
+    json: jest.fn(),
+  } as unknown as Response;
+  (res.status as jest.Mock).mockReturnValue(res);
+  return res;
+}
+
+function request(overrides: Partial<Request> = {}) {
+  return {
+    body: {},
+    headers: {},
+    params: { jobId: 'job-1' },
+    logger: { error: jest.fn() },
+    serverOptions: {
+      mediaApi: {
+        baseUrl: 'https://media.example.test',
+        apiKey: 'upstream-secret',
+        timeoutMs: 5000,
+      },
+    },
+    ...overrides,
+  } as unknown as Request;
+}
+
+describe('media controller', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('forwards job creation status and body', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ duplicate: false, data: { id: 'job-1' } }),
+        {
+          status: 202,
+        }
+      )
+    );
+    const req = request({
+      body: { sourceUrl: 'https://cdn.example.test/voice.mp3' },
+      headers: { 'idempotency-key': 'controller-smoke-1' },
+    });
+    const res = response();
+
+    await createConversion(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(res.json).toHaveBeenCalledWith({
+      duplicate: false,
+      data: { id: 'job-1' },
+    });
+  });
+
+  it('returns a clear disabled response when the adapter is not configured', async () => {
+    const req = request({
+      serverOptions: {
+        mediaApi: { baseUrl: null, apiKey: null, timeoutMs: 5000 },
+      } as Request['serverOptions'],
+    });
+    const res = response();
+
+    await getJob(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      status: 'error',
+      message:
+        'Media API is not configured. Set MEDIA_API_URL and MEDIA_API_KEY.',
+    });
+  });
+});

--- a/src/tests/core/mediaApiClient.test.ts
+++ b/src/tests/core/mediaApiClient.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  MediaApiAdapterError,
+  MediaApiClient,
+} from '../../core/media/MediaApiClient';
+
+const settings = {
+  baseUrl: 'https://media.example.test/',
+  apiKey: 'media-secret',
+  timeoutMs: 5000,
+};
+
+describe('MediaApiClient', () => {
+  it('requires an explicitly configured service and key', () => {
+    expect(
+      () => new MediaApiClient({ baseUrl: null, apiKey: null, timeoutMs: 5000 })
+    ).toThrow(
+      new MediaApiAdapterError(
+        'Media API is not configured. Set MEDIA_API_URL and MEDIA_API_KEY.',
+        503
+      )
+    );
+  });
+
+  it('forwards JSON conversion jobs with isolated upstream credentials', async () => {
+    const fetcher = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { id: 'job-1' } }), {
+        status: 202,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const client = new MediaApiClient(settings, fetcher);
+
+    const result = await client.createConversion(
+      { sourceUrl: 'https://cdn.example.test/audio.mp3' },
+      'conversion-1234'
+    );
+
+    expect(result).toEqual({ status: 202, body: { data: { id: 'job-1' } } });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [url, init] = fetcher.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://media.example.test/v1/audio/conversions');
+    expect(new Headers(init.headers).get('authorization')).toBe(
+      'Bearer media-secret'
+    );
+    expect(new Headers(init.headers).get('idempotency-key')).toBe(
+      'conversion-1234'
+    );
+    expect(init.body).toBe(
+      JSON.stringify({ sourceUrl: 'https://cdn.example.test/audio.mp3' })
+    );
+  });
+
+  it('forwards multipart transcription uploads without setting the boundary', async () => {
+    const fetcher = jest
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: { id: 'job-2' } }), { status: 202 })
+      );
+    const client = new MediaApiClient(settings, fetcher);
+
+    await client.createTranscription(
+      { language: 'pt', webhookUrl: 'https://hooks.example.test/media' },
+      'transcription-1234',
+      {
+        bytes: new Uint8Array([1, 2, 3]),
+        filename: 'voice.ogg',
+        mimeType: 'audio/ogg',
+      }
+    );
+
+    const init = fetcher.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.has('content-type')).toBe(false);
+    expect(init.body).toBeInstanceOf(FormData);
+    const form = init.body as FormData;
+    expect(form.get('language')).toBe('pt');
+    expect(form.get('webhookUrl')).toBe('https://hooks.example.test/media');
+    const file = form.get('file') as File;
+    expect(file.name).toBe('voice.ogg');
+    expect(file.type).toBe('audio/ogg');
+    expect(file.size).toBe(3);
+  });
+
+  it('encodes job ids and preserves upstream errors', async () => {
+    const fetcher = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Job not found' }), {
+        status: 404,
+      })
+    );
+    const client = new MediaApiClient(settings, fetcher);
+
+    const result = await client.getJob('job/unsafe');
+
+    expect(fetcher.mock.calls[0][0]).toBe(
+      'https://media.example.test/v1/jobs/job%2Funsafe'
+    );
+    expect(result).toEqual({ status: 404, body: { error: 'Job not found' } });
+  });
+
+  it('maps transport failures to a safe gateway error', async () => {
+    const client = new MediaApiClient(
+      settings,
+      jest.fn().mockRejectedValue(new Error('socket details'))
+    );
+
+    await expect(client.getJob('job-1')).rejects.toEqual(
+      new MediaApiAdapterError('Media API is unavailable', 502)
+    );
+  });
+
+  it('distinguishes upstream timeouts from other transport failures', async () => {
+    const timeout = new Error('deadline exceeded');
+    timeout.name = 'TimeoutError';
+    const client = new MediaApiClient(
+      settings,
+      jest.fn().mockRejectedValue(timeout)
+    );
+
+    await expect(client.getJob('job-1')).rejects.toEqual(
+      new MediaApiAdapterError('Media API request timed out', 504)
+    );
+  });
+});

--- a/src/types/ServerOptions.ts
+++ b/src/types/ServerOptions.ts
@@ -44,6 +44,11 @@ export interface ServerOptions {
     enable: boolean;
     prefix: string;
   };
+  mediaApi: {
+    baseUrl: string | null;
+    apiKey: string | null;
+    timeoutMs: number;
+  };
   db: {
     mongodbDatabase: string;
     mongodbCollection: string;


### PR DESCRIPTION
## Summary
- add an opt-in Media API client for conversion, transcription, and job polling
- expose authenticated WPPConnect Server proxy routes for JSON URLs and multipart uploads
- keep the upstream API key server-side, enforce timeouts, clean temporary uploads, and preserve upstream status bodies
- document environment variables and wire them into the Docker Compose example

## Validation
- yarn test --runInBand (48 tests)
- yarn build
- targeted ESLint on all changed TypeScript files
- docker compose config --quiet

The adapter remains disabled until MEDIA_API_URL and MEDIA_API_KEY are configured.