### PR TITLE
feat: embed WPPConnect Manager with authenticated session APIs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,5 @@ log
 node_modules
 npm-debug.log
 tokens
+graphify-out
+manager

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Build source
         run: yarn build
 
+      - name: Test server and Manager contracts
+        run: yarn test --runInBand
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,14 +55,49 @@ jobs:
             type=sha,prefix=sha-
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: Build and push
+      - name: Build image for verification
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          load: true
+          tags: manager-integration-test:local
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Verify integrated Manager and disabled mode
+        shell: bash
+        run: |
+          docker run -d --name manager-enabled -p 21465:21465 -e SECRET_KEY=manager-ci-secret manager-integration-test:local
+          for n in $(seq 1 60); do curl -fsS http://localhost:21465/api/manager/info > /dev/null && break || sleep 1; done
+          curl -fsS http://localhost:21465/api/manager/info | grep '"protocol":1'
+          curl -fsS http://localhost:21465/manager/ | grep 'WPPConnect Manager'
+          curl -fsS http://localhost:21465/manager/sessions/test | grep 'WPPConnect Manager'
+          curl -fsS http://localhost:21465/manager/config.js | grep 'WPP_MANAGER_CONFIG'
+          curl -fsSL http://localhost:21465/api-docs/ > /dev/null
+          test "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:21465/api/manager/sessions)" = 401
+          curl -fsS -H 'Authorization: Bearer manager-ci-secret' http://localhost:21465/api/manager/sessions | grep '"sessions":\[\]'
+          test "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:21465/manager/missing.js)" = 404
+          docker run -d --name manager-disabled -p 21466:21465 -e MANAGER_ENABLED=false manager-integration-test:local
+          for n in $(seq 1 60); do curl -fsS http://localhost:21466/api/manager/info > /dev/null && break || sleep 1; done
+          curl -fsS http://localhost:21466/api/manager/info | grep '"protocol":1'
+          test "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:21466/manager/)" = 404
+
+      - name: Publish verified image
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        shell: bash
+        run: |
+          while IFS= read -r tag; do
+            docker tag manager-integration-test:local "$tag"
+            docker push "$tag"
+          done <<< "$IMAGE_TAGS"
+
+      - name: Container diagnostics
+        if: failure()
+        run: |
+          docker logs manager-enabled || true
+          docker logs manager-disabled || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM node:22.22.2-alpine AS manager
+ARG MANAGER_VERSION=2.0.0
+ARG MANAGER_SHA256=e5cd47cbd56c5eca53751947cf5799f75aa5a4b4d7c2bf189471374a48b9ff7f
+RUN wget -q -O /tmp/manager.tar.gz "https://github.com/wppconnect-team/wppconnect-manager/releases/download/v${MANAGER_VERSION}/wppconnect-manager.tar.gz" && \
+    echo "${MANAGER_SHA256}  /tmp/manager.tar.gz" | sha256sum -c - && \
+    mkdir /manager && tar -xzf /tmp/manager.tar.gz -C /manager
+
 FROM node:22.22.2-alpine AS base
 WORKDIR /usr/src/wpp-server
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
@@ -46,4 +53,6 @@ RUN apk add --no-cache \
     fftw
 
 EXPOSE 21465
+COPY --from=manager /manager ./manager
+ENV MANAGER_ENABLED=true
 ENTRYPOINT ["node", "dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 ## _WPPConnect Server_
 
+### WPPConnect Manager
+
+The Docker image includes [WPPConnect Manager](https://github.com/wppconnect-team/wppconnect-manager) at **http://localhost:21465/manager/**: server profiles, session management and QR pairing, chat, contacts, groups and media, with Portuguese/English and light/dark themes.
+
+Use `SECRET_KEY` for administration, or a session name/token for restricted access. Credentials remain in browser memory. Set `MANAGER_ENABLED=false` to disable serving the UI. The image pins and verifies the Manager bundle during build.
+
+See [configuration, API, authenticated events and rollback](docs/manager.md). Existing APIs and legacy sockets remain compatible. Live WhatsApp send/receive requires separate validation with an authorized account.
+
 ![WPPConnect-SERVER](https://i.imgur.com/y1ts6RR.png)
 
 [![npm version](https://img.shields.io/npm/v/@wppconnect/server.svg?color=green)](https://www.npmjs.com/package/@wppconnect/server)

--- a/docs/manager.md
+++ b/docs/manager.md
@@ -15,6 +15,8 @@ Use HTTPS remotely. A reverse proxy must forward `/manager/`, `/api/` and `/sock
 
 ## HTTP protocol 1
 
+Manager API requests are limited to 60 per minute per source IP, and static UI requests to 300 per minute. Excess requests return 429. Behind a proxy, the existing server proxy/IP configuration determines which clients share a limit.
+
 Manager responses use `Cache-Control: no-store`. Administrative credentials go in `Authorization: Bearer <SECRET_KEY>`, never URL segments. Legacy routes remain available.
 
 | Method | Path | Authorization | Result |

--- a/docs/manager.md
+++ b/docs/manager.md
@@ -1,0 +1,54 @@
+# WPPConnect Manager integration
+
+The companion [WPPConnect Manager](https://github.com/wppconnect-team/wppconnect-manager) provides session administration, QR pairing, chats, contacts, groups and media in Portuguese and English.
+
+## Serving the UI
+
+The Docker image includes the static bundle at `/manager/`. Its release version and SHA-256 are fixed in the Dockerfile and verified during the build. Starting a container does not download UI code. The default profile points at the same origin.
+
+- `MANAGER_ENABLED=false` disables static UI routes. The API continues working.
+- `MANAGER_DIST=/absolute/path/to/bundle` selects a local bundle for non-Docker use. By default the server looks for `manager` in its working directory and mounts no UI routes if absent.
+- `/api/`, `/api-docs`, `/files` and the original socket namespace retain their existing behavior.
+- `/manager/` and client navigation paths serve the application; missing asset filenames return 404.
+
+Use HTTPS remotely. A reverse proxy must forward `/manager/`, `/api/` and `/socket.io/`, including WebSocket upgrades. A separate Manager container uses the browser-visible server URL as `MANAGER_SERVER_URL`; Docker-internal hostnames usually are not browser-visible.
+
+## HTTP protocol 1
+
+Manager responses use `Cache-Control: no-store`. Administrative credentials go in `Authorization: Bearer <SECRET_KEY>`, never URL segments. Legacy routes remain available.
+
+| Method | Path | Authorization | Result |
+| --- | --- | --- | --- |
+| GET | `/api/manager/info` | None | `protocol: 1`, server version and feature names. |
+| GET | `/api/manager/sessions` | Secret key | `{sessions: [{session, status}]}` from stored tokens and live clients. |
+| POST | `/api/manager/sessions/:session/token` | Secret key | `{session, token}` using the existing bcrypt token format. |
+| POST | `/api/manager/verify` | Session token | Body `{session}`; `{authorized: true}` or HTTP 401. |
+| DELETE | `/api/manager/sessions/:session` | Secret key | Removes token and user-data directory for a closed session; `{success: true}`. |
+
+Names accepted by new routes contain 1–100 ASCII letters, digits, underscores or hyphens, beginning with a letter or digit. Reserved object/array property names are rejected. HTTP 400 means invalid input, 401 invalid credentials, 409 an active session or symlink directory, and 500 a failed operation. Failed cleanup must not be treated as successful.
+
+Session tokens authorize only their own session. They cannot list all sessions or perform administrative cleanup. The Manager uses existing session, message, contact, group and media endpoints after obtaining a token.
+
+There is no new user database. Browser profiles persist only names and URLs; credentials remain in memory and are lost on reload/sign-out.
+
+## Authenticated Socket.IO namespace
+
+Connect to `/manager` with handshake auth `{session, token}`. The transport path remains `/socket.io/`. Only valid session tokens are accepted; secret keys are not socket credentials. The server selects the room from the authenticated session; clients cannot join arbitrary rooms.
+
+Events use `{session, data}` envelopes:
+
+- `message`: WhatsApp message with stable ID and originating session.
+- `status`: `{status}` when state changes or login completes/fails.
+- `qrCode`: `{qrcode}` with the image data URL.
+
+The UI polls authenticated status/QR endpoints to reconcile missed changes. Reconnection reloads available history and deduplicates by message ID. This is not durable event replay; WhatsApp/server must still have that history/media.
+
+The original namespace retains compatibility behavior. Its legacy broadcasts are not the authenticated Manager channel; the new UI never subscribes to them.
+
+## Validation and rollback
+
+`yarn test --runInBand` runs source tests, including real HTTP/socket checks with isolated storage. Docker CI starts the built image and verifies the UI, discovery, unauthenticated rejection, deep links and disabled mode before publication.
+
+Manager browser tests use synthetic data. Real WhatsApp pairing and text/media send/receive require a separately authorized test account; passing unit/browser/image checks does not prove live operations.
+
+Record image tags/digests before upgrading. Roll back by restoring the previous server image and matching standalone Manager, if used. There is no database migration. The initial pre-integration source baseline was `7c73fd39ce56b6ffa52e22e951cfdcfc06ce96b8` (package 2.10.16); deployments must record their own previous image digest.

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testMatch: ['**/src/**/*.test.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "release-it": "^19.2.4",
     "rimraf": "^6.1.3",
     "shx": "^0.4.0",
+    "socket.io-client": "4.8.3",
     "swagger-ui-dist": "^5.32.14",
     "ts-jest": "^29.4.12",
     "ts-loader": "^9.5.4",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "dotenv": "^16.6.1",
     "express": "4.22.2",
     "express-query-boolean": "^2.0.0",
+    "express-rate-limit": "^8.2.0",
     "form-data": "^4.0.6",
     "json-mapper-json": "^1.3.3",
     "merge-deep": "^3.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,9 @@ import { Logger } from 'winston';
 
 import { version } from '../package.json';
 import config from './config';
+import { managerRoutes } from './manager/routes';
+import { installManagerSocket } from './manager/socket';
+import { installManagerStatic } from './manager/static';
 import { convert } from './mapper/index';
 import routes from './routes';
 import { ServerOptions } from './types/ServerOptions';
@@ -98,6 +101,8 @@ export function initServer(serverOptions: Partial<ServerOptions>): {
     next();
   });
 
+  app.use('/api/manager', managerRoutes);
+  installManagerStatic(app);
   app.use(routes);
 
   createFolders();
@@ -108,6 +113,7 @@ export function initServer(serverOptions: Partial<ServerOptions>): {
     },
   });
 
+  installManagerSocket(io, serverOptions.secretKey!);
   io.on('connection', (sock) => {
     logger.info(`ID: ${sock.id} entrou`);
 

--- a/src/manager/auth.ts
+++ b/src/manager/auth.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import bcrypt from 'bcrypt';
+import { timingSafeEqual } from 'crypto';
+
+export function validSession(session: unknown): session is string {
+  return (
+    typeof session === 'string' &&
+    /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,99}$/.test(session) &&
+    !(session in [])
+  );
+}
+
+export function isAdmin(token: unknown, secret: string): boolean {
+  if (typeof token !== 'string' || !token || !secret) return false;
+  const a = Buffer.from(token);
+  const b = Buffer.from(secret);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export async function sessionAuthorized(
+  session: unknown,
+  token: unknown,
+  secret: string
+) {
+  if (!validSession(session) || typeof token !== 'string' || token.length > 200)
+    return false;
+  const hash = token.replace(/_/g, '/').replace(/-/g, '+');
+  // Server-issued tokens use cost 10. Reject attacker-supplied expensive hashes.
+  if (!/^\$2[aby]\$10\$[./A-Za-z0-9]{53}$/.test(hash)) return false;
+  return bcrypt.compare(session + secret, hash).catch(() => false);
+}

--- a/src/manager/manager.test.ts
+++ b/src/manager/manager.test.ts
@@ -220,5 +220,8 @@ describe('Manager HTTP and authenticated events', () => {
       response = await request('/sessions', 'invalid');
     expect(response?.status).toBe(429);
     expect(response?.headers.get('ratelimit')).toBeTruthy();
+    expect(await response?.json()).toEqual({
+      message: 'Too many requests. Try again later.',
+    });
   });
 });

--- a/src/manager/manager.test.ts
+++ b/src/manager/manager.test.ts
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import bcrypt from 'bcrypt';
+import express from 'express';
+import { promises as fs } from 'fs';
+import { createServer, Server as HttpServer } from 'http';
+import { AddressInfo } from 'net';
+import os from 'os';
+import path from 'path';
+import { Server } from 'socket.io';
+import { io as connect, Socket } from 'socket.io-client';
+
+import { clientsArray } from '../util/sessionUtil';
+import { managerRoutes } from './routes';
+import { emitManager, installManagerSocket } from './socket';
+import { installManagerStatic } from './static';
+
+const saved = new Set<string>(['alpha']);
+jest.mock('../util/tokenStore/factory', () => ({
+  __esModule: true,
+  default: class {
+    createTokenStory() {
+      return {
+        listTokens: async () => [...saved],
+        removeToken: async (s: string) => saved.delete(s),
+      };
+    }
+  },
+}));
+jest.mock('../util/sessionUtil', () => ({ clientsArray: {} }));
+
+describe('Manager HTTP and authenticated events', () => {
+  let http: HttpServer;
+  let socketServer: Server;
+  let base: string;
+  let directory: string;
+  const sockets: Socket[] = [];
+  beforeAll(async () => {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'wpp-manager-test-'));
+    await fs.writeFile(
+      path.join(directory, 'index.html'),
+      '<html>Manager fixture</html>'
+    );
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.serverOptions = {
+        secretKey: 'test-secret',
+        customUserDataDir: directory,
+      } as any;
+      next();
+    });
+    app.use('/api/manager', managerRoutes);
+    installManagerStatic(app, directory);
+    app.get('/api/legacy', (_req, res) => res.json({ legacy: true }));
+    http = createServer(app);
+    socketServer = new Server(http);
+    installManagerSocket(socketServer, 'test-secret');
+    await new Promise<void>((resolve) => http.listen(0, '127.0.0.1', resolve));
+    base = `http://127.0.0.1:${(http.address() as AddressInfo).port}`;
+  });
+  afterAll(async () => {
+    sockets.forEach((s) => s.disconnect());
+    await new Promise<void>((resolve) => socketServer.close(() => resolve()));
+    // The exact mkdtemp directory is the only deletion target.
+    if (path.dirname(directory) !== path.resolve(os.tmpdir()))
+      throw Error('Invalid cleanup directory');
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  async function request(
+    endpoint: string,
+    token = 'test-secret',
+    method = 'GET'
+  ) {
+    return fetch(`${base}/api/manager${endpoint}`, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  }
+  test('requires administration credentials and never returns them in discovery', async () => {
+    expect((await request('/sessions', 'bad')).status).toBe(401);
+    const res = await request('/sessions');
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    expect(await res.json()).toEqual({
+      sessions: [{ session: 'alpha', status: 'CLOSED' }],
+    });
+    expect(await (await request('/info')).text()).not.toContain('test-secret');
+  });
+  test('issued tokens authorize only the named session, not administration', async () => {
+    const { token } = (await (
+      await request('/sessions/alpha/token', 'test-secret', 'POST')
+    ).json()) as any;
+    expect(
+      await bcrypt.compare(
+        'alphatest-secret',
+        token.replace(/_/g, '/').replace(/-/g, '+')
+      )
+    ).toBe(true);
+    expect((await request('/sessions', token)).status).toBe(401);
+    const verify = (session: string) =>
+      fetch(`${base}/api/manager/verify`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ session }),
+      });
+    expect((await verify('alpha')).status).toBe(200);
+    expect((await verify('beta')).status).toBe(401);
+  });
+  test.each(['..%2foutside', 'constructor', 'length', 'bad%3Aname'])(
+    'rejects unsafe session %s',
+    async (session) => {
+      expect(
+        (await request(`/sessions/${session}/token`, 'test-secret', 'POST'))
+          .status
+      ).toBe(400);
+    }
+  );
+  test('cannot clear active sessions; clears only a closed session and its stored token', async () => {
+    (clientsArray as any).alpha = { status: 'CONNECTED' };
+    await fs.mkdir(path.join(directory, 'alpha'));
+    await fs.writeFile(path.join(directory, 'alpha', 'data'), 'fixture');
+    expect(
+      (await request('/sessions/alpha', 'test-secret', 'DELETE')).status
+    ).toBe(409);
+    expect(saved.has('alpha')).toBe(true);
+    (clientsArray as any).alpha = { status: null };
+    expect(
+      (await request('/sessions/alpha', 'test-secret', 'DELETE')).status
+    ).toBe(200);
+    expect(saved.has('alpha')).toBe(false);
+    await expect(fs.stat(path.join(directory, 'alpha'))).rejects.toThrow();
+  });
+  test('serves deep links without intercepting API or missing assets', async () => {
+    expect((await fetch(`${base}/manager/`)).status).toBe(200);
+    expect(
+      await (await fetch(`${base}/manager/sessions/alpha`)).text()
+    ).toContain('Manager fixture');
+    expect((await fetch(`${base}/manager/missing.js`)).status).toBe(404);
+    expect(await (await fetch(`${base}/api/legacy`)).json()).toEqual({
+      legacy: true,
+    });
+  });
+  test('disabling the Manager does not register static routes', async () => {
+    process.env.MANAGER_ENABLED = 'false';
+    const app = express();
+    installManagerStatic(app, directory);
+    delete process.env.MANAGER_ENABLED;
+    expect(app._router).toBeUndefined();
+  });
+  test('rejects unauthenticated sockets and cross-session tokens', async () => {
+    const token = await bcrypt.hash('alphatest-secret', 10);
+    for (const auth of [{}, { session: 'beta', token }]) {
+      const socket = connect(`${base}/manager`, { auth, reconnection: false });
+      sockets.push(socket);
+      const error = await new Promise<Error>((resolve) =>
+        socket.once('connect_error', resolve)
+      );
+      expect(error.message).toBe('Unauthorized');
+      socket.disconnect();
+    }
+  });
+  test('only the authorized room receives its messages; legacy socket still connects', async () => {
+    const alpha = connect(`${base}/manager`, {
+      auth: {
+        session: 'alpha',
+        token: await bcrypt.hash('alphatest-secret', 10),
+      },
+    });
+    const beta = connect(`${base}/manager`, {
+      auth: {
+        session: 'beta',
+        token: await bcrypt.hash('betatest-secret', 10),
+      },
+    });
+    const legacy = connect(base);
+    sockets.push(alpha, beta, legacy);
+    await Promise.all(
+      [alpha, beta, legacy].map((s) =>
+        s.connected
+          ? Promise.resolve()
+          : new Promise<void>((resolve) => s.once('connect', resolve))
+      )
+    );
+    const received: any[] = [];
+    beta.on('message', (message) => received.push(message));
+    const response = new Promise<any>((resolve) =>
+      alpha.once('message', resolve)
+    );
+    emitManager(socketServer, 'alpha', 'message', { body: 'only alpha' });
+    expect(await response).toEqual({
+      session: 'alpha',
+      data: { body: 'only alpha' },
+    });
+    const barrier = new Promise<void>((resolve) =>
+      beta.once('barrier', resolve)
+    );
+    socketServer.of('/manager').to('session:beta').emit('barrier');
+    await barrier;
+    expect(received).toEqual([]);
+  });
+});

--- a/src/manager/manager.test.ts
+++ b/src/manager/manager.test.ts
@@ -214,4 +214,11 @@ describe('Manager HTTP and authenticated events', () => {
     await barrier;
     expect(received).toEqual([]);
   });
+  test('bounds repeated authorization attempts with HTTP 429', async () => {
+    let response: Response | undefined;
+    for (let n = 0; n < 61; n++)
+      response = await request('/sessions', 'invalid');
+    expect(response?.status).toBe(429);
+    expect(response?.headers.get('ratelimit')).toBeTruthy();
+  });
 });

--- a/src/manager/routes.ts
+++ b/src/manager/routes.ts
@@ -31,6 +31,8 @@ managerRoutes.use(
     limit: 60,
     standardHeaders: 'draft-7',
     legacyHeaders: false,
+    handler: (_req, res) =>
+      res.status(429).json({ message: 'Too many requests. Try again later.' }),
   })
 );
 managerRoutes.use((_req, res, next) => {

--- a/src/manager/routes.ts
+++ b/src/manager/routes.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import bcrypt from 'bcrypt';
+import { Router } from 'express';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { version } from '../../package.json';
+import { clientsArray } from '../util/sessionUtil';
+import Factory from '../util/tokenStore/factory';
+import { isAdmin, sessionAuthorized, validSession } from './auth';
+
+export const managerRoutes = Router();
+managerRoutes.use((_req, res, next) => {
+  res.setHeader('Cache-Control', 'no-store');
+  next();
+});
+managerRoutes.get('/info', (_req, res) => {
+  res.json({
+    protocol: 1,
+    serverVersion: version,
+    features: ['sessions', 'chat', 'contacts', 'groups', 'media'],
+  });
+});
+managerRoutes.post('/verify', async (req, res) => {
+  const token = req.headers.authorization?.replace(/^Bearer /, '');
+  const authorized = await sessionAuthorized(
+    req.body.session,
+    token,
+    req.serverOptions.secretKey
+  );
+  res.status(authorized ? 200 : 401).json({ authorized });
+});
+managerRoutes.use((req, res, next) => {
+  const token = req.headers.authorization?.replace(/^Bearer /, '');
+  if (!isAdmin(token, req.serverOptions.secretKey))
+    return res.status(401).json({ message: 'Unauthorized' });
+  next();
+});
+managerRoutes.get('/sessions', async (req, res) => {
+  try {
+    const store = new Factory().createTokenStory(null);
+    const saved = await store.listTokens();
+    const names = [
+      ...new Set([...(saved || []), ...Object.keys(clientsArray)]),
+    ];
+    res.json({
+      sessions: names.map((session) => ({
+        session,
+        status: (clientsArray[session] as any)?.status || 'CLOSED',
+      })),
+    });
+  } catch {
+    res.status(500).json({ message: 'Unable to list sessions' });
+  }
+});
+managerRoutes.param('session', (req, res, next, session) => {
+  if (!validSession(session))
+    return res.status(400).json({ message: 'Invalid session name' });
+  next();
+});
+managerRoutes.post('/sessions/:session/token', async (req, res) => {
+  try {
+    const token = await bcrypt.hash(
+      req.params.session + req.serverOptions.secretKey,
+      10
+    );
+    res.status(201).json({
+      session: req.params.session,
+      token: token.replace(/\//g, '_').replace(/\+/g, '-'),
+    });
+  } catch {
+    res.status(500).json({ message: 'Unable to generate token' });
+  }
+});
+managerRoutes.delete('/sessions/:session', async (req, res) => {
+  const session = req.params.session;
+  try {
+    const client = clientsArray[session];
+    if (client?.status && !['CLOSED', 'DISCONNECTED'].includes(client.status)) {
+      return res
+        .status(409)
+        .json({ message: 'Close the session before clearing its data' });
+    }
+    const root = path.resolve(req.serverOptions.customUserDataDir);
+    const target = path.resolve(root, session);
+    if (path.dirname(target) !== root)
+      return res.status(400).json({ message: 'Invalid session path' });
+    // Do not follow a user-data symlink outside the configured directory.
+    const stat = await fs.lstat(target).catch((error) => {
+      if (error.code !== 'ENOENT') throw error;
+      return null;
+    });
+    if (stat?.isSymbolicLink())
+      return res
+        .status(409)
+        .json({ message: 'Symlink session directories cannot be cleared' });
+    const store = new Factory().createTokenStory(null);
+    const saved = await store.listTokens();
+    if (saved.includes(session) && !(await store.removeToken(session))) {
+      return res
+        .status(500)
+        .json({ message: 'Unable to remove session token' });
+    }
+    await fs.rm(target, { recursive: true, force: true });
+    delete clientsArray[session];
+    res.json({ success: true });
+  } catch {
+    res.status(500).json({ message: 'Unable to clear session data' });
+  }
+});

--- a/src/manager/routes.ts
+++ b/src/manager/routes.ts
@@ -15,6 +15,7 @@
  */
 import bcrypt from 'bcrypt';
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { promises as fs } from 'fs';
 import path from 'path';
 
@@ -24,6 +25,14 @@ import Factory from '../util/tokenStore/factory';
 import { isAdmin, sessionAuthorized, validSession } from './auth';
 
 export const managerRoutes = Router();
+managerRoutes.use(
+  rateLimit({
+    windowMs: 60_000,
+    limit: 60,
+    standardHeaders: 'draft-7',
+    legacyHeaders: false,
+  })
+);
 managerRoutes.use((_req, res, next) => {
   res.setHeader('Cache-Control', 'no-store');
   next();
@@ -96,7 +105,10 @@ managerRoutes.delete('/sessions/:session', async (req, res) => {
         .json({ message: 'Close the session before clearing its data' });
     }
     const root = path.resolve(req.serverOptions.customUserDataDir);
-    const target = path.resolve(root, session);
+    const leaf = path.basename(session);
+    if (leaf !== session || leaf === '.' || leaf === '..')
+      return res.status(400).json({ message: 'Invalid session path' });
+    const target = path.resolve(root, leaf);
     if (path.dirname(target) !== root)
       return res.status(400).json({ message: 'Invalid session path' });
     // Do not follow a user-data symlink outside the configured directory.

--- a/src/manager/socket.ts
+++ b/src/manager/socket.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Server } from 'socket.io';
+
+import { sessionAuthorized } from './auth';
+
+export function installManagerSocket(io: Server, secret: string) {
+  const namespace = io.of('/manager');
+  namespace.use(async (socket, next) => {
+    const { session, token } = socket.handshake.auth;
+    if (!(await sessionAuthorized(session, token, secret)))
+      return next(new Error('Unauthorized'));
+    socket.data.session = session;
+    next();
+  });
+  namespace.on('connection', (socket) => {
+    // Session is fixed by the authenticated handshake. No client-controlled room joins.
+    socket.join(`session:${socket.data.session}`);
+  });
+}
+
+export function emitManager(
+  io: Server,
+  session: string,
+  event: string,
+  data: unknown
+) {
+  io.of('/manager').to(`session:${session}`).emit(event, { session, data });
+}

--- a/src/manager/static.ts
+++ b/src/manager/static.ts
@@ -34,6 +34,10 @@ export function installManagerStatic(
       limit: 300,
       standardHeaders: 'draft-7',
       legacyHeaders: false,
+      handler: (_req, res) =>
+        res
+          .status(429)
+          .json({ message: 'Too many requests. Try again later.' }),
     })
   );
   app.get('/manager', (req, res, next) =>

--- a/src/manager/static.ts
+++ b/src/manager/static.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import express, { Express } from 'express';
+import { existsSync } from 'fs';
+import path from 'path';
+
+export function installManagerStatic(
+  app: Express,
+  directory = process.env.MANAGER_DIST || path.resolve('manager')
+) {
+  if (
+    process.env.MANAGER_ENABLED === 'false' ||
+    !existsSync(path.join(directory, 'index.html'))
+  )
+    return;
+  app.get('/manager', (req, res, next) =>
+    req.path.endsWith('/') ? next() : res.redirect('/manager/')
+  );
+  app.use('/manager', express.static(directory, { index: 'index.html' }));
+  app.get('/manager/*', (req, res, next) => {
+    if (path.extname(req.path)) return next();
+    res.setHeader('Cache-Control', 'no-cache');
+    res.sendFile(path.resolve(directory, 'index.html'));
+  });
+}

--- a/src/manager/static.ts
+++ b/src/manager/static.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import express, { Express } from 'express';
+import rateLimit from 'express-rate-limit';
 import { existsSync } from 'fs';
 import path from 'path';
 
@@ -26,6 +27,15 @@ export function installManagerStatic(
     !existsSync(path.join(directory, 'index.html'))
   )
     return;
+  app.use(
+    '/manager',
+    rateLimit({
+      windowMs: 60_000,
+      limit: 300,
+      standardHeaders: 'draft-7',
+      legacyHeaders: false,
+    })
+  );
   app.get('/manager', (req, res, next) =>
     req.path.endsWith('/') ? next() : res.redirect('/manager/')
   );

--- a/src/types/express/index.d.ts
+++ b/src/types/express/index.d.ts
@@ -1,5 +1,5 @@
 import { Whatsapp } from '@wppconnect-team/wppconnect';
-import { Socket } from 'socket.io';
+import { Server } from 'socket.io';
 import { Logger } from 'winston';
 
 import { ServerOptions } from '../ServerOptions';
@@ -14,7 +14,7 @@ declare global {
       logger: Logger;
       session: string;
       token?: string;
-      io: Socket;
+      io: Server;
       serverOptions: ServerOptions;
     }
   }

--- a/src/util/createSessionUtil.ts
+++ b/src/util/createSessionUtil.ts
@@ -17,6 +17,7 @@ import { create, SocketState, StatusFind } from '@wppconnect-team/wppconnect';
 import { Request } from 'express';
 
 import { download } from '../controller/sessionController';
+import { emitManager } from '../manager/socket';
 import { WhatsAppServer } from '../types/WhatsAppServer';
 import chatWootClient from './chatWootClient';
 import { autoDownload, callWebHook, startHelper } from './functions';
@@ -221,6 +222,9 @@ export default class CreateSessionUtil {
       data: 'data:image/png;base64,' + imageBuffer.toString('base64'),
       session: client.session,
     });
+    emitManager(req.io, client.session, 'qrCode', {
+      qrcode: 'data:image/png;base64,' + imageBuffer.toString('base64'),
+    });
 
     callWebHook(client, req, 'qrcode', {
       qrcode: qrCode,
@@ -250,10 +254,12 @@ export default class CreateSessionUtil {
       req.logger.info(`Started Session: ${client.session}`);
       //callWebHook(client, req, 'session-logged', { status: 'CONNECTED'});
       req.io.emit('session-logged', { status: true, session: client.session });
+      emitManager(req.io, client.session, 'status', { status: 'CONNECTED' });
       startHelper(client, req);
     } catch (error) {
       req.logger.error(error);
       req.io.emit('session-error', client.session);
+      emitManager(req.io, client.session, 'status', { status: 'ERROR' });
     }
 
     await this.checkStateSession(client, req);
@@ -270,6 +276,7 @@ export default class CreateSessionUtil {
 
   async checkStateSession(client: WhatsAppServer, req: Request) {
     await client.onStateChange((state) => {
+      emitManager(req.io, client.session, 'status', { status: state });
       req.logger.info(`State Change ${state}: ${client.session}`);
       const conflits = [SocketState.CONFLICT];
 
@@ -304,6 +311,7 @@ export default class CreateSessionUtil {
       }
 
       req.io.emit('received-message', { response: message });
+      emitManager(req.io, client.session, 'message', message);
       if (req.serverOptions.webhook.onSelfMessage && message.fromMe)
         callWebHook(client, req, 'onselfmessage', message);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6292,6 +6292,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     express: "npm:4.22.2"
     express-query-boolean: "npm:^2.0.0"
+    express-rate-limit: "npm:^8.2.0"
     form-data: "npm:^4.0.6"
     husky: "npm:^9.1.7"
     jest: "npm:^30.4.2"
@@ -9666,6 +9667,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^8.2.0":
+  version: 8.7.0
+  resolution: "express-rate-limit@npm:8.7.0"
+  dependencies:
+    debug: "npm:^4.4.3"
+    ip-address: "npm:^10.2.0"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 10c0/a83aca1af73280e07695bcb989d40835691b3cbec411782ac56a49d20555008acdcfedd8235c2df63ad8fd60288a9e1a73760a10bba3b3a8160b270f417b05b8
+  languageName: node
+  linkType: hard
+
 "express@npm:4.22.2":
   version: 4.22.2
   resolution: "express@npm:4.22.2"
@@ -11076,6 +11089,13 @@ __metadata:
   version: 10.5.0
   resolution: "ip-address@npm:10.5.0"
   checksum: 10c0/c6616bc99c90b552dad2beb850ca697c1ea3e2b89662d652a4439cd72a549b0c9af100a54be0d25be86599e2b089db87ef5303157d142e5b4c21bd2a1301dfa7
+  languageName: node
+  linkType: hard
+
+"ip-address@npm:^10.2.0":
+  version: 10.7.0
+  resolution: "ip-address@npm:10.7.0"
+  checksum: 10c0/bb6f514708b84ec75ad4d8156f3d571a5b8e592a15359386100f4f8d7366a4b7723d54b88a30d80b3f51ca5f4dee239e94ef4b53765b9c41a8ea46b421307d14
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6312,6 +6312,7 @@ __metadata:
     sharp: "npm:^0.35.0"
     shx: "npm:^0.4.0"
     socket.io: "npm:^4.8.3"
+    socket.io-client: "npm:4.8.3"
     swagger-autogen: "npm:^2.23.7"
     swagger-ui-dist: "npm:^5.32.14"
     swagger-ui-express: "npm:^5.0.1"
@@ -8820,6 +8821,19 @@ __metadata:
   dependencies:
     once: "npm:^1.4.0"
   checksum: 10c0/b0701c92a10b89afb1cb45bf54a5292c6f008d744eb4382fa559d54775ff31617d1d7bc3ef617575f552e24fad2c7c1a1835948c66b3f3a4be0a6c1f35c883d8
+  languageName: node
+  linkType: hard
+
+"engine.io-client@npm:~6.6.1":
+  version: 6.6.6
+  resolution: "engine.io-client@npm:6.6.6"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.4.1"
+    engine.io-parser: "npm:~5.2.1"
+    ws: "npm:~8.21.0"
+    xmlhttprequest-ssl: "npm:~2.1.1"
+  checksum: 10c0/805995b57b2656f52322004b4d767851b517618b1fcecabf5968c55ce6864c692e594fe3a6ae9284504aa087a5a872b0ea1b76b876dcf4cf866907bd61e9e1dd
   languageName: node
   linkType: hard
 
@@ -15337,6 +15351,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"socket.io-client@npm:4.8.3":
+  version: 4.8.3
+  resolution: "socket.io-client@npm:4.8.3"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.4.1"
+    engine.io-client: "npm:~6.6.1"
+    socket.io-parser: "npm:~4.2.4"
+  checksum: 10c0/76c0d86de0b636d0bf5011cf3425212c900f43dac632db6eb493816920cd035af7ddd92fea9a106b45eb347405953c0414eb3a5d465b180215e46fc8b61420b3
+  languageName: node
+  linkType: hard
+
 "socket.io-parser@npm:~4.2.4":
   version: 4.2.7
   resolution: "socket.io-parser@npm:4.2.7"
@@ -17027,6 +17053,13 @@ __metadata:
   version: 0.3.0
   resolution: "xml-naming@npm:0.3.0"
   checksum: 10c0/48bfc4fe888cdf1c3eceb7853632ebce59e4aa71f0ae33c3f9ce1fbd3213caad293457de0a311114491f0d4efcfba70977dcba3a4f66dfed8c92edbb938056bf
+  languageName: node
+  linkType: hard
+
+"xmlhttprequest-ssl@npm:~2.1.1":
+  version: 2.1.2
+  resolution: "xmlhttprequest-ssl@npm:2.1.2"
+  checksum: 10c0/70d60869323e823f473a238f78fd108437edbc3690ecd5859c39c83217080090a18899b272e515769c0d1f518cc64cbed6b6995b23fdd7ba13b297d530b6e631
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds WPPConnect Manager at /manager/ in the server image, pinned to release 2.0.0 with its verified SHA-256. MANAGER_ENABLED=false disables static serving; existing API/docs/files and legacy socket behavior remain compatible.

Adds header-authenticated Manager administration endpoints and session-token verification, plus a separate authenticated Socket.IO namespace with server-selected session rooms. New events come from the existing session lifecycle and message callbacks. Manager routes have IP rate limits with JSON HTTP 429 responses. Cleanup rejects active sessions, constrains filesystem paths to validated leaf names, rejects symlink directories and checks token deletion results.

Docker CI now runs the image and checks static routing, discovery, unauthorized access and disabled mode before publishing. Jest runs source tests only, avoiding accidental compiled-test duplication after builds. Includes integration documentation and README setup/rollback guidance.

Validation: 25 source tests passed, including real HTTP/socket authorization and isolation checks; TypeScript/build and lint checked locally. Manager v2.0.0 passed 11 client tests, 12 desktop/mobile browser scenarios and Docker CI. Real WhatsApp pairing/send/receive remains pending an authorized test account.

Manager source/release: https://github.com/wppconnect-team/wppconnect-manager/releases/tag/v2.0.0
