### PR TITLE
fix: load and document optional environment configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,7 @@ npm-debug.log
 tokens
 graphify-out
 manager
+
+.env
+.env.*
+!.env.example

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# Copy to .env and replace SECRET_KEY before using the server.
+# Node loads .env from its working directory. Existing environment values win.
+# Docker Compose forwards the supported variables below to the container.
+# Empty optional values retain their defaults. This file contains no real secrets.
+
+SECRET_KEY=replace-with-a-long-random-secret
+HOST=http://localhost
+# Compose uses PORT for both the container listener and the published host port.
+PORT=21465
+WEBHOOK_URL=
+
+# Supported token stores: file, redis, mongodb.
+TOKEN_STORE_TYPE=file
+MAX_LISTENERS=15
+# Keep a trailing slash. Relative paths use the server working directory.
+# In Compose, keep data inside the userDataDir volume or adjust the volume too.
+CUSTOM_USER_DATA_DIR=./userDataDir/
+
+# The UI is bundled in the Docker image. Set false to disable /manager/.
+MANAGER_ENABLED=true
+# Optional static bundle path. Empty uses ./manager (local) or the image bundle.
+# Container paths refer to paths inside the container.
+MANAGER_DIST=
+
+# Only used with TOKEN_STORE_TYPE=redis. Provision the Redis server separately.
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+REDIS_DB=0
+REDIS_PREFIX=docker
+
+# Only used with TOKEN_STORE_TYPE=mongodb. Provision MongoDB separately.
+# MONGO_URL_REMOTE is the connection URI used by the default remote mode.
+MONGO_URL_REMOTE=
+MONGODB_DATABASE=tokens
+MONGODB_COLLECTION=
+# The following host/user/port fields apply when db.mongoIsRemote=false in config.ts.
+MONGODB_USER=
+MONGODB_PASSWORD=
+MONGODB_HOST=
+MONGODB_PORT=27017
+
+# Docker Compose only: pin a published X.Y.Z tag for reproducible deployments.
+WPP_SERVER_TAG=latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Check Compose environment contract
+        run: node scripts/check-compose-config.cjs
+
+      - name: Prepare private build-context fixtures
+        run: |
+          printf 'SECRET_KEY=build-context-test\nPORT=24552\nMAX_LISTENERS=27\n' > .env
+          printf 'SECRET_KEY=private-context-test\n' > .env.production
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -67,6 +75,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Verify optional env file and packaging
+        shell: bash
+        run: |
+          docker run --rm --entrypoint node manager-integration-test:local -e "const fs=require('fs'),a=require('assert/strict');a.equal(fs.existsSync('.env'),false);a.equal(fs.existsSync('.env.production'),false);a.equal(fs.existsSync('.env.example'),true)"
+          docker run --rm --entrypoint node -v "$PWD/.env:/usr/src/wpp-server/.env:ro" -e PORT=24553 manager-integration-test:local -e "const a=require('assert/strict'),c=require('./dist/config').default;a.equal(c.secretKey,'build-context-test');a.equal(c.port,'24553');a.equal(c.maxListeners,27)"
+
       - name: Verify integrated Manager and disabled mode
         shell: bash
         run: |
@@ -85,6 +99,18 @@ jobs:
           curl -fsS http://localhost:21466/api/manager/info | grep '"protocol":1'
           test "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:21466/manager/)" = 404
 
+      - name: Verify Compose runtime with env file
+        shell: bash
+        run: |
+          docker tag manager-integration-test:local wppconnect/wppconnect-server:ci-env
+          printf 'WPP_SERVER_TAG=ci-env\nPORT=21467\nSECRET_KEY=compose-ci-secret\nMANAGER_ENABLED=false\n' > .ci-env
+          docker compose -p manager-env-ci --env-file .ci-env up -d --no-build --pull never
+          for n in $(seq 1 60); do curl -fsS http://localhost:21467/api/manager/info > /dev/null && break || sleep 1; done
+          curl -fsS http://localhost:21467/healthz > /dev/null
+          curl -fsS -H 'Authorization: Bearer compose-ci-secret' http://localhost:21467/api/manager/sessions | grep '"sessions":\[\]'
+          test "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:21467/manager/)" = 404
+          docker compose -p manager-env-ci --env-file .ci-env down -v
+
       - name: Publish verified image
         if: github.event_name != 'pull_request'
         env:
@@ -101,3 +127,4 @@ jobs:
         run: |
           docker logs manager-enabled || true
           docker logs manager-disabled || true
+          docker logs wpp-server || true

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ userDataDir
 backupFolder
 tokens/*
 wppconnect_tokens/*
+.env
+.env.*
+!.env.example

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@
 nodemon.json
 requests.http
 yarn.lock
+!.env.example

--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ docker run -d \
   wppconnect/wppconnect-server:latest
 ```
 
-For Docker Compose, clone the repository and run:
+For Docker Compose, clone the repository, copy the example and edit `SECRET_KEY`:
 
 ```sh
-SECRET_KEY=change-me docker compose up -d
+cp .env.example .env
+# Edit .env and replace SECRET_KEY. In PowerShell, use Copy-Item .env.example .env.
+docker compose up -d
 docker compose ps
 curl http://localhost:21465/healthz
 ```
@@ -100,7 +102,7 @@ curl http://localhost:21465/healthz
 Set `WPP_SERVER_TAG` to pin a release instead of following `latest`:
 
 ```sh
-WPP_SERVER_TAG=2.10 SECRET_KEY=change-me docker compose up -d
+WPP_SERVER_TAG=2.10.18 docker compose up -d
 ```
 
 Release tags follow the GitHub and npm version: `vX.Y.Z`, `X.Y.Z`, `X.Y`,
@@ -123,12 +125,12 @@ docker compose up -d
 
 ## Installation from source
 
-Install the dependencies and start the server.
+Install the dependencies, copy `.env.example` to `.env`, and edit `SECRET_KEY`. Node loads `.env` from the directory where you start the server; existing environment variables take precedence. The file is optional.
 
 ```sh
-yarn install
-//or
-npm install
+yarn install --immutable
+cp .env.example .env
+# PowerShell: Copy-Item .env.example .env
 ```
 
 ## Install puppeteer dependencies:
@@ -178,137 +180,40 @@ yarn build
 
 # Configuration
 
-This server use config.ts file to define some options, default values are:
+Configuration defaults remain in [src/config.ts](src/config.ts). Supported environment variables are documented in [.env.example](.env.example); the file is also included in the npm package.
 
-```javascript
-{
-  /* secret key to generate access token */
-  secretKey: 'THISISMYSECURETOKEN',
-  host: 'http://localhost',
-  port: '21465',
-  // Device name for show on whatsapp device
-  deviceName: 'WppConnect',
-  poweredBy: 'WPPConnect-Server',
-  // starts all sessions when starting the server.
-  startAllSession: true,
-  tokenStoreType: 'file',
-  // sets the maximum global listeners. 0 = infinity.
-  maxListeners: 15,
-  // create userDataDir for each puppeteer instance for working with Multi Device
-  customUserDataDir: './userDataDir/',
-  webhook: {
-    // set default webhook
-    url: null,
-    // automatically downloads files to upload to the webhook
-    autoDownload: true,
-    // enable upload to s3
-    uploadS3: false,
-    // set default bucket name on aws s3
-    awsBucketName: null,
-    //marks messages as read when the webhook returns ok
-    readMessage: true,
-    //sends all unread messages to the webhook when the server starts
-    allUnreadOnStart: false,
-    // send all events of message status (read, sent, etc)
-    listenAcks: true,
-    // send all events of contacts online or offline for webook and socket
-    onPresenceChanged: true,
-    // send all events of groups participants changed for webook and socket
-    onParticipantsChanged: true,
-    // send all events of reacted messages for webook and socket
-    onReactionMessage: true,
-    // send all events of poll messages for webook and socket
-    onPollResponse: true,
-    // send all events of revoked messages for webook and socket
-    onRevokedMessage: true,
-    // send all events of labels for webook and socket
-    onLabelUpdated: true,
-    // 'event', 'from' or 'type' to ignore and not send to webhook
-    ignore: [],
-  },
-  websocket: {
-    // Just leave one active, here or on webhook.autoDownload
-    autoDownload: false,
-    // Just leave one active, here or on webhook.uploadS3, to avoid duplication in S3
-    uploadS3: false,
-  },
-  // send data to chatwoot
-  chatwoot: {
-    sendQrCode: true,
-    sendStatus: true,
-  },
-  //functionality that archives conversations, runs when the server starts
-  archive: {
-    enable: false,
-    //maximum interval between filings.
-    waitTime: 10,
-    daysToArchive: 45,
-  },
-  log: {
-    level: 'silly', // Before open a issue, change level to silly and retry an action
-    logger: ['console', 'file'],
-  },
-  // create options for using on wppconnect-lib
-  createOptions: {
-    browserArgs: [
-      '--disable-web-security',
-      '--no-sandbox',
-      '--disable-web-security',
-      '--aggressive-cache-discard',
-      '--disable-cache',
-      '--disable-application-cache',
-      '--disable-offline-load-stale-cache',
-      '--disk-cache-size=0',
-      '--disable-background-networking',
-      '--disable-default-apps',
-      '--disable-extensions',
-      '--disable-sync',
-      '--disable-translate',
-      '--hide-scrollbars',
-      '--metrics-recording-only',
-      '--mute-audio',
-      '--no-first-run',
-      '--safebrowsing-disable-auto-update',
-      '--ignore-certificate-errors',
-      '--ignore-ssl-errors',
-      '--ignore-certificate-errors-spki-list',
-      '--disable-features=LeakyPeeker' // Disable the browser's sleep mode when idle, preventing the browser from going into sleep mode, this is useful for WhatsApp not to be in economy mode in the background, avoiding possible crashes
-    ],
-  },
-  mapper: {
-    enable: false,
-    prefix: 'tagone-',
-  },
-  // Configurations for connect with database
-  db: {
-    mongodbDatabase: 'tokens',
-    mongodbCollection: '',
-    mongodbUser: '',
-    mongodbPassword: '',
-    mongodbHost: '',
-    mongoIsRemote: true,
-    mongoURLRemote: '',
-    mongodbPort: 27017,
-    redisHost: 'localhost',
-    redisPort: 6379,
-    redisPassword: '',
-    redisDb: 0,
-    redisPrefix: 'docker',
-  },
-  // Your configurations to upload on AWS
-  aws_s3: {
-    region: 'sa-east-1',
-    access_key_id: '',
-    secret_key: '',
-    // If you already have a bucket created that will be used. Will be stored: you-default-bucket/{session}/{filename}
-    defaultBucketName: ''
-  },
-}
+The default configuration resolves values in this order: existing process environment, optional `.env` in the working directory, then built-in defaults. Restart the process or recreate the container after changing a value. Variables are read at runtime, so changing them does not require rebuilding the image.
+
+| Area | Variables |
+| --- | --- |
+| Server | `SECRET_KEY`, `HOST`, `PORT`, `WEBHOOK_URL` |
+| Sessions | `TOKEN_STORE_TYPE`, `CUSTOM_USER_DATA_DIR`, `MAX_LISTENERS` |
+| Manager | `MANAGER_ENABLED`, `MANAGER_DIST` |
+| Redis | `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DB`, `REDIS_PREFIX` |
+| MongoDB | `MONGO_URL_REMOTE`, `MONGODB_DATABASE`, `MONGODB_COLLECTION`, `MONGODB_USER`, `MONGODB_PASSWORD`, `MONGODB_HOST`, `MONGODB_PORT` |
+| Compose image | `WPP_SERVER_TAG` (used by Compose, not the Node server) |
+
+For Node, both `yarn dev` and the compiled `yarn start` load the optional file automatically. For example, after setting `PORT=21470` in `.env`, the server listens on port 21470. `HOST` supplies the advertised URL; it does not restrict the listener address.
+
+Compose reads `.env` for interpolation and explicitly forwards the supported server variables. Setting `PORT=21470` changes both the container listener and the published host port; setting `MANAGER_ENABLED=false` disables `/manager/` while the API remains available. You can select another file with `docker compose --env-file ./server.env up -d`. Variables defined by the shell take precedence over values in the file.
+
+For plain Docker, pass variables with `-e` or `--env-file`:
+
+```sh
+docker run --rm --env-file .env -p 21465:21465 wppconnect/wppconnect-server:2.10.18
 ```
+
+If `PORT` differs from 21465, adjust both sides of `-p` accordingly. Use the persistent volumes shown in the Docker section for regular deployments. Private `.env` files are excluded from image builds and npm packages; `.env.example` remains available. Docker does not need a private file baked into the image.
+
+Paths in containers refer to the container filesystem. Keep `CUSTOM_USER_DATA_DIR` inside the mounted session-data directory (and retain its trailing slash), or change the volume mapping too. `MANAGER_DIST` points to an existing static bundle; leaving it empty uses the default location. The official Docker image supplies that bundle.
+
+Redis and MongoDB services must be provisioned separately; the included Compose file starts only WPPConnect. The default MongoDB remote mode uses `MONGO_URL_REMOTE`. Structured MongoDB host/user/port settings apply when `db.mongoIsRemote` is disabled in the advanced configuration.
+
+Advanced options without an environment mapping, such as browser arguments and webhook event toggles, remain in `src/config.ts` or can be supplied to `initServer(...)` when embedding the server. Changing TypeScript configuration requires rebuilding the compiled server; environment-only changes do not.
 
 # Secret Key
 
-Your `secretKey` is inside the `config.ts` file. You must change the default value to one that only you know.
+Set `SECRET_KEY` in `.env` or the deployment environment to a private, randomly generated value. The legacy default is retained for compatibility; replace it before exposing the API. Never commit your private `.env`.
 
 <!-- ![Peek 2021-03-25 09-33](https://user-images.githubusercontent.com/40338524/112473515-3b310a80-8d4d-11eb-94bb-ff409c91d9b8.gif) -->
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The default configuration resolves values in this order: existing process enviro
 
 For Node, both `yarn dev` and the compiled `yarn start` load the optional file automatically. For example, after setting `PORT=21470` in `.env`, the server listens on port 21470. `HOST` supplies the advertised URL; it does not restrict the listener address.
 
-Compose reads `.env` for interpolation and explicitly forwards the supported server variables. Setting `PORT=21470` changes both the container listener and the published host port; setting `MANAGER_ENABLED=false` disables `/manager/` while the API remains available. You can select another file with `docker compose --env-file ./server.env up -d`. Variables defined by the shell take precedence over values in the file.
+Compose reads `.env` for interpolation and explicitly forwards the supported server variables. Setting `PORT=21470` changes both the container listener and the published host port; setting `MANAGER_ENABLED=false` disables `/manager/` while the API remains available. You can select another file with `docker compose --env-file ./.env.production up -d`. Variables defined by the shell take precedence over values in the file.
 
 For plain Docker, pass variables with `-e` or `--env-file`:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,27 @@ services:
     image: wppconnect/wppconnect-server:${WPP_SERVER_TAG:-latest}
     restart: unless-stopped
     environment:
-      PORT: "21465"
-      HOST: "http://localhost"
-      SECRET_KEY: "${SECRET_KEY:-THISISMYSECURETOKEN}"
-      WEBHOOK_URL: "${WEBHOOK_URL:-}"
-      TOKEN_STORE_TYPE: "${TOKEN_STORE_TYPE:-file}"
-      CUSTOM_USER_DATA_DIR: "/usr/src/wpp-server/userDataDir/"
+      PORT: '${PORT:-21465}'
+      HOST: '${HOST:-http://localhost}'
+      SECRET_KEY: '${SECRET_KEY:-THISISMYSECURETOKEN}'
+      WEBHOOK_URL: '${WEBHOOK_URL:-}'
+      TOKEN_STORE_TYPE: '${TOKEN_STORE_TYPE:-file}'
+      CUSTOM_USER_DATA_DIR: '${CUSTOM_USER_DATA_DIR:-/usr/src/wpp-server/userDataDir/}'
+      MAX_LISTENERS: '${MAX_LISTENERS:-15}'
+      MANAGER_ENABLED: '${MANAGER_ENABLED:-true}'
+      MANAGER_DIST: '${MANAGER_DIST:-/usr/src/wpp-server/manager}'
+      MONGODB_DATABASE: '${MONGODB_DATABASE:-tokens}'
+      MONGODB_COLLECTION: '${MONGODB_COLLECTION:-}'
+      MONGODB_USER: '${MONGODB_USER:-}'
+      MONGODB_PASSWORD: '${MONGODB_PASSWORD:-}'
+      MONGODB_HOST: '${MONGODB_HOST:-}'
+      MONGO_URL_REMOTE: '${MONGO_URL_REMOTE:-}'
+      MONGODB_PORT: '${MONGODB_PORT:-27017}'
+      REDIS_HOST: '${REDIS_HOST:-localhost}'
+      REDIS_PORT: '${REDIS_PORT:-6379}'
+      REDIS_PASSWORD: '${REDIS_PASSWORD:-}'
+      REDIS_DB: '${REDIS_DB:-0}'
+      REDIS_PREFIX: '${REDIS_PREFIX:-docker}'
     volumes:
       - wppconnect_tokens:/usr/src/wpp-server/tokens
       - wppconnect_user_data:/usr/src/wpp-server/userDataDir
@@ -17,9 +32,13 @@ services:
       - wppconnect_images:/usr/src/wpp-server/WhatsAppImages
       - wppconnect_logs:/usr/src/wpp-server/log
     ports:
-      - "21465:21465"
+      - '${PORT:-21465}:${PORT:-21465}'
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:$${PORT:-21465}/healthz || exit 1"]
+      test:
+        [
+          'CMD-SHELL',
+          'wget -q --spider http://127.0.0.1:$${PORT:-21465}/healthz || exit 1',
+        ]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/scripts/check-compose-config.cjs
+++ b/scripts/check-compose-config.cjs
@@ -1,0 +1,84 @@
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'wppconnect-compose-'));
+const values = {
+  WPP_SERVER_TAG: '2.10.18',
+  PORT: '24552',
+  HOST: 'https://server.example.test',
+  SECRET_KEY: 'compose-test-key',
+  WEBHOOK_URL: 'https://hooks.example.test/events',
+  TOKEN_STORE_TYPE: 'redis',
+  CUSTOM_USER_DATA_DIR: './userDataDir/',
+  MAX_LISTENERS: '27',
+  MANAGER_ENABLED: 'false',
+  MANAGER_DIST: '/opt/manager',
+  MONGODB_DATABASE: 'test-db',
+  MONGODB_COLLECTION: 'test-sessions',
+  MONGODB_USER: 'test-user',
+  MONGODB_PASSWORD: 'test-password',
+  MONGODB_HOST: 'mongo.example.test',
+  MONGO_URL_REMOTE: 'mongodb://mongo.example.test:27018/test-db',
+  MONGODB_PORT: '27018',
+  REDIS_HOST: 'redis.example.test',
+  REDIS_PORT: '6399',
+  REDIS_PASSWORD: 'redis-test-password',
+  REDIS_DB: '2',
+  REDIS_PREFIX: 'test-prefix',
+};
+const environment = { ...process.env };
+for (const name of Object.keys(values)) delete environment[name];
+function render(contents) {
+  const file = path.join(directory, '.env');
+  fs.writeFileSync(file, contents);
+  return JSON.parse(
+    execFileSync(
+      'docker',
+      [
+        'compose',
+        '-f',
+        path.join(root, 'docker-compose.yml'),
+        '--env-file',
+        file,
+        'config',
+        '--format',
+        'json',
+      ],
+      { cwd: root, env: environment, encoding: 'utf8' }
+    )
+  ).services.wppconnect;
+}
+try {
+  const configured = render(
+    Object.entries(values)
+      .map(([key, value]) => key + '=' + value)
+      .join('\n')
+  );
+  for (const [name, value] of Object.entries(values)) {
+    if (name === 'WPP_SERVER_TAG')
+      assert.equal(configured.image, 'wppconnect/wppconnect-server:' + value);
+    else
+      assert.equal(
+        String(configured.environment[name]),
+        value,
+        name + ' must reach the container'
+      );
+  }
+  assert.equal(String(configured.ports[0].published), '24552');
+  assert.equal(configured.ports[0].target, 24552);
+  const defaults = render('');
+  assert.equal(String(defaults.environment.PORT), '21465');
+  assert.equal(String(defaults.environment.MANAGER_ENABLED), 'true');
+  assert.equal(defaults.image, 'wppconnect/wppconnect-server:latest');
+  console.log(
+    'Compose defaults, port mapping and all documented variables passed'
+  );
+} finally {
+  if (path.dirname(directory) !== path.resolve(os.tmpdir()))
+    throw new Error('Unexpected test directory');
+  fs.rmSync(directory, { recursive: true, force: true });
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+const originalEnv = process.env;
+let directory: string;
+let cwd: jest.SpyInstance;
+
+beforeEach(() => {
+  directory = mkdtempSync(path.join(tmpdir(), 'wppconnect-env-'));
+  cwd = jest.spyOn(process, 'cwd').mockReturnValue(directory);
+  process.env = { ...originalEnv };
+  delete process.env.SECRET_KEY;
+  delete process.env.PORT;
+  delete process.env.MAX_LISTENERS;
+  jest.resetModules();
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  cwd.mockRestore();
+  if (path.dirname(directory) !== path.resolve(tmpdir()))
+    throw new Error('Unexpected test directory');
+  rmSync(directory, { recursive: true, force: true });
+});
+
+it('loads the optional cwd .env before resolving server settings', async () => {
+  writeFileSync(
+    directory + '/.env',
+    'SECRET_KEY=test-env-key\nPORT=24552\nMAX_LISTENERS=27\n'
+  );
+  const { default: config } = await import('./config');
+  expect(config.secretKey).toBe('test-env-key');
+  expect(config.port).toBe('24552');
+  expect(config.maxListeners).toBe(27);
+});
+
+it('keeps deployment environment values ahead of the .env file', async () => {
+  writeFileSync(
+    directory + '/.env',
+    'SECRET_KEY=file-key\nPORT=24552\nMAX_LISTENERS=27\n'
+  );
+  process.env.SECRET_KEY = 'deployment-key';
+  process.env.PORT = '24553';
+  process.env.MAX_LISTENERS = '0';
+  const { default: config } = await import('./config');
+  expect(config.secretKey).toBe('deployment-key');
+  expect(config.port).toBe('24553');
+  expect(config.maxListeners).toBe(0);
+});
+
+it('starts with legacy defaults when no .env exists', async () => {
+  const { default: config } = await import('./config');
+  expect(config.secretKey).toBe('THISISMYSECURETOKEN');
+  expect(config.port).toBe('21465');
+  expect(config.maxListeners).toBe(15);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,9 @@
+import dotenv from 'dotenv';
+
 import { ServerOptions } from './types/ServerOptions';
 
+// Loading is optional; deployment environment variables keep precedence.
+dotenv.config({ override: false });
 const env = process.env;
 
 function envNumber(name: string, fallback: number): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,6 @@ import {
 } from './util/functions';
 import { createLogger } from './util/logger';
 
-//require('dotenv').config();
-
 export const logger = createLogger(config.log);
 
 export function initServer(serverOptions: Partial<ServerOptions>): {


### PR DESCRIPTION
The server read process.env but never loaded a local .env file, while the Compose file silently ignored settings such as PORT, MANAGER_ENABLED and Redis/MongoDB variables. Load the optional working-directory .env before resolving config.ts, preserve deployment environment precedence, and forward all documented settings through Compose with matching listener/host ports.

Add a commented .env.example to Git and the npm package, exclude private .env files from image builds, and replace the stale README configuration dump with instructions for Node, Docker and Compose. Advanced config.ts options remain available.

Validation: 28 tests pass, including the env-file regression demonstrated failing before the change, missing-file defaults and environment precedence. Typecheck, build, lint and the Compose configuration contract pass. npm pack confirms the example is included and private env files are excluded. Docker CI additionally checks build-context exclusions, a mounted .env with environment overrides, and an actual Compose deployment with a custom port and Manager disabled before publishing the image.

Fixes #2552.
